### PR TITLE
feat: add some improvements for error

### DIFF
--- a/client/src/components/AddCredentialDialog.tsx
+++ b/client/src/components/AddCredentialDialog.tsx
@@ -104,8 +104,11 @@ const AddCredentialDialog: React.FC<AddCredentialDialogProps> = ({
       fetchCredentials();
       fetchAvailableCredentials();
     } catch (error) {
-      console.error("Failed to create credential:", error);
-      toast.error("Failed to add credential. Please try again.");
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("Failed to create credential")
+      }
     } finally {
       setIsSubmitting(false);
     }
@@ -139,7 +142,6 @@ const AddCredentialDialog: React.FC<AddCredentialDialogProps> = ({
         toast.error("Invalid credentials. Please check and try again.");
       }
     } catch (error) {
-      console.error("Error testing credentials:", error);
       toast.error("An error occurred while testing credentials.");
     } finally {
       setIsTestingCredentials(false);

--- a/client/src/components/CredentialList.tsx
+++ b/client/src/components/CredentialList.tsx
@@ -51,6 +51,7 @@ import useAuthStore from "@/stores/user.store";
 import useOrganizationStore from "@/stores/organization.store";
 import { ClickHouseCredential } from "@/types/types";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { toast } from "sonner";
 
 interface CredentialListProps {
   credentials: ClickHouseCredential[];
@@ -167,46 +168,82 @@ const CredentialList: React.FC<CredentialListProps> = ({
 
   const handleConfirmAddUser = async () => {
     if (credentialToManage && selectedUserId) {
-      await assignUserToCredential(credentialToManage._id, selectedUserId);
-      setAddUserDialogOpen(false);
-      setCredentialToManage(null);
-      setSelectedUserId("");
+      try {
+        await assignUserToCredential(credentialToManage._id, selectedUserId);
+        setAddUserDialogOpen(false);
+        setCredentialToManage(null);
+        setSelectedUserId("");
+        toast.success("User assigned to credential successfully");
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to assign user to credential")
+        }
+      }
     }
   };
 
   const handleConfirmRemoveUser = async () => {
     if (credentialToManage && selectedUserId) {
-      await revokeUserFromCredential(credentialToManage._id, selectedUserId);
-      setRemoveUserDialogOpen(false);
-      setCredentialToManage(null);
-      setSelectedUserId("");
+      try {
+        await revokeUserFromCredential(credentialToManage._id, selectedUserId);
+        setRemoveUserDialogOpen(false);
+        setCredentialToManage(null);
+        setSelectedUserId("");
+        toast.success("User revoked from credential successfully");
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to revoke user from credential")
+        }
+      }
     }
   };
 
   const handleConfirmAddOrg = async () => {
     if (credentialToManage && selectedOrgId) {
-      await assignCredentialToOrganization(
-        credentialToManage._id,
-        selectedOrgId
-      );
-      setAddOrgDialogOpen(false);
-      setCredentialToManage(null);
-      setSelectedOrgId("");
-      fetchCredentials();
-      fetchOrganizations();
-      fetchAvailableCredentials();
+      try {
+        await assignCredentialToOrganization(
+          credentialToManage._id,
+          selectedOrgId
+        );
+        toast.success("Credential assigned to organization successfully");
+        setAddOrgDialogOpen(false);
+        setCredentialToManage(null);
+        setSelectedOrgId("");
+        fetchCredentials();
+        fetchOrganizations();
+        fetchAvailableCredentials();
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to assign credential to organization")
+        }
+      }
     }
   };
 
   const handleConfirmRemoveOrg = async () => {
     if (credentialToManage && selectedOrgId) {
-      await revokeCredentialFromOrganization(
-        credentialToManage._id,
-        selectedOrgId
-      );
-      setRemoveOrgDialogOpen(false);
-      setCredentialToManage(null);
-      setSelectedOrgId("");
+      try {
+        await revokeCredentialFromOrganization(
+          credentialToManage._id,
+          selectedOrgId
+        );
+        setRemoveOrgDialogOpen(false);
+        setCredentialToManage(null);
+        setSelectedOrgId("");
+        toast.success("Credential revoked from organization successfully");
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to revoke credential from organization")
+        }
+      }
     }
   };
 

--- a/client/src/components/OrganizationCredentialSelector.tsx
+++ b/client/src/components/OrganizationCredentialSelector.tsx
@@ -48,7 +48,7 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
   React.useEffect(() => {
     if (user?.activeOrganization?._id) {
       setTempOrgValue(user.activeOrganization._id);
-      fetchCredentials(user.activeOrganization._id)
+      fetchAvailbleCredentialsAndHandleErrors(user.activeOrganization._id)
     }
     if (user?.activeClickhouseCredential?._id) {
       setTempCredValue(user.activeClickhouseCredential._id);
@@ -69,7 +69,7 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
     setDialogOpen(false);
   };
 
-  const fetchCredentials = async (organizationId: string) => {
+  const fetchAvailbleCredentialsAndHandleErrors = async (organizationId: string) => {
     try {
       await fetchAvailableCredentials(organizationId);
     } catch(error) {
@@ -85,7 +85,7 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
     setTempOrgValue(organizationId);
     resetCredentials();
     setTempCredValue("");
-    await fetchCredentials(organizationId)
+    await fetchAvailbleCredentialsAndHandleErrors(organizationId)
   };
 
   const handleCredSelect = (credentialId: string) => {

--- a/client/src/components/OrganizationCredentialSelector.tsx
+++ b/client/src/components/OrganizationCredentialSelector.tsx
@@ -48,7 +48,7 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
   React.useEffect(() => {
     if (user?.activeOrganization?._id) {
       setTempOrgValue(user.activeOrganization._id);
-      fetchAvailableCredentials(user.activeOrganization._id);
+      fetchCredentials(user.activeOrganization._id)
     }
     if (user?.activeClickhouseCredential?._id) {
       setTempCredValue(user.activeClickhouseCredential._id);
@@ -69,11 +69,23 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
     setDialogOpen(false);
   };
 
+  const fetchCredentials = async (organizationId: string) => {
+    try {
+      await fetchAvailableCredentials(organizationId);
+    } catch(error) {
+      if (error instanceof Error) {
+        toast.error(error.message)
+      } {
+        toast.error("Failed to fetch available credentials")
+      }
+    }
+  }
+
   const handleOrgSelect = async (organizationId: string) => {
     setTempOrgValue(organizationId);
     resetCredentials();
     setTempCredValue("");
-    await fetchAvailableCredentials(organizationId);
+    await fetchCredentials(organizationId)
   };
 
   const handleCredSelect = (credentialId: string) => {
@@ -92,7 +104,6 @@ export function CombinedSelector({ isExpanded }: { isExpanded: boolean }) {
       toast.success("Organization and credential updated successfully.");
       setDialogOpen(false);
     } catch (error: any) {
-      console.error("Update failed:", error);
       toast.error(`Failed to update: ${error.message}`);
     }
   };

--- a/client/src/components/UpdateCredentialDialog.tsx
+++ b/client/src/components/UpdateCredentialDialog.tsx
@@ -97,13 +97,16 @@ const UpdateCredentialDialog: React.FC<UpdateCredentialDialogProps> = ({
           // Only include password if it's not empty
           ...(data.password && { password: data.password }),
         });
-        toast.success("Credential updated successfully!");
         onClose();
         setIsCredentialValid(false);
+        toast.success("Credential updated successfully");
       }
     } catch (error) {
-      console.error("Failed to update credential:", error);
-      toast.error("Failed to update credential. Please try again.");
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("Failed to update credentials")
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/client/src/pages/Credentials.tsx
+++ b/client/src/pages/Credentials.tsx
@@ -64,6 +64,22 @@ function CredentialsPage() {
     setSortOrder(sortOrder === "asc" ? "desc" : "asc");
   };
 
+  const deleteCredential = (credentialId: string) => {
+    try {
+      useClickHouseCredentialStore
+        .getState()
+        .deleteCredential(credentialId);
+      toast.success("Credential deleted successfully");
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("Failed to delete credentials")
+      }
+    }
+    
+  }
+
   return (
     <div className="container mx-auto my-6 max-w-8xl">
       <Card className="h-[calc(100vh-8rem)] flex flex-col">
@@ -138,9 +154,7 @@ function CredentialsPage() {
                   setIsUpdateDialogOpen(true);
                 }}
                 onDelete={(cred) => {
-                  useClickHouseCredentialStore
-                    .getState()
-                    .deleteCredential(cred._id);
+                  deleteCredential(cred._id)
                 }}
               />
             </>

--- a/client/src/pages/Credentials.tsx
+++ b/client/src/pages/Credentials.tsx
@@ -17,7 +17,6 @@ function CredentialsPage() {
     credentials,
     fetchCredentials,
     isLoading,
-    error,
     setSelectedCredential,
   } = useClickHouseCredentialStore();
   const [isAddDialogOpen, setIsAddDialogOpen] = useState(false);
@@ -29,14 +28,16 @@ function CredentialsPage() {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("asc");
 
   useEffect(() => {
-    fetchCredentials();
-  }, [fetchCredentials]);
-
-  useEffect(() => {
-    if (error) {
-      toast.error(error);
+    try {
+      fetchCredentials();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message);
+      } else {
+        toast.error("Failed to fetch credentials");
+      }
     }
-  }, [error]);
+  }, [fetchCredentials]);
 
   const filteredCredentials = credentials
     .filter((cred) =>

--- a/client/src/stores/clickHouseCredentials.store.ts
+++ b/client/src/stores/clickHouseCredentials.store.ts
@@ -1,7 +1,6 @@
 // clickHouseCredentials store
 import { create } from "zustand";
 import api from "@/api/axios.config";
-import { toast } from "sonner";
 import { ClickHouseCredentialState, ClickHouseCredential } from "@/types/types";
 import { isAxiosError } from "axios";
 
@@ -10,13 +9,11 @@ const useClickHouseCredentialStore = create<ClickHouseCredentialState>(
     credentials: [],
     selectedCredential: null,
     availableCredentials: [],
-    isLoading: false,
-    error: null,
 
     fetchCredentials: async () => {
       try {
         const response = await api.get("/clickhouse-credentials");
-        set({ credentials: response.data, isLoading: false });
+        set({ credentials: response.data });
       } catch (error) {
         throw new Error("Failed to fetch credentials")
       }
@@ -60,80 +57,82 @@ const useClickHouseCredentialStore = create<ClickHouseCredentialState>(
     },
 
     deleteCredential: async (id) => {
-      set({ isLoading: true, error: null });
       try {
         await api.delete(`/clickhouse-credentials/${id}`);
         await get().fetchCredentials();
-        toast.success("Credential deleted successfully");
       } catch (error) {
-        set({ error: "Failed to delete credential", isLoading: false });
-        toast.error("Failed to delete credential");
+        let msg = "Failed to delete credential"
+        if (isAxiosError(error)) {
+          msg = `${msg}: ${error.response?.data.message}`
+        }
+        throw new Error(msg)
       }
     },
 
     assignCredentialToOrganization: async (credentialId, organizationId) => {
-      set({ isLoading: true, error: null });
       try {
         await api.post(
           `/clickhouse-credentials/${credentialId}/organizations`,
           { organizationId }
         );
         await get().fetchCredentials();
-        toast.success("Credential assigned to organization successfully");
       } catch (error) {
-        set({
-          error: "Failed to assign credential to organization",
-          isLoading: false,
-        });
-        toast.error("Failed to assign credential to organization");
+        let msg = "Failed to assign credential to organization";
+        if (isAxiosError(error)) {
+          msg = `${msg}: ${error.response?.data.message}`
+        }
+        throw new Error(msg)
       }
     },
 
     revokeCredentialFromOrganization: async (credentialId, organizationId) => {
-      set({ isLoading: true, error: null });
       try {
         await api.delete(
           `/clickhouse-credentials/${credentialId}/organizations/${organizationId}`
         );
         await get().fetchCredentials();
-        toast.success("Credential revoked from organization successfully");
       } catch (error) {
-        set({
-          error: "Failed to revoke credential from organization",
-          isLoading: false,
-        });
-        toast.error("Failed to revoke credential from organization");
+        let msg = "Failed to revoke credential from organization"
+        if (isAxiosError(error)) {
+          if (isAxiosError(error)) {
+            msg = `${msg}: ${error.response?.data.message}`
+          }
+          throw new Error(msg)
+        }
       }
     },
 
     assignUserToCredential: async (credentialId, userId) => {
-      set({ isLoading: true, error: null });
       try {
         await api.post(`/clickhouse-credentials/${credentialId}/users`, {
           userId,
         });
         await get().fetchCredentials();
-        toast.success("User assigned to credential successfully");
       } catch (error) {
-        set({ error: "Failed to assign user to credential", isLoading: false });
-        toast.error("Failed to assign user to credential");
+        let msg = "Failed to assign user to credential"
+        if (isAxiosError(error)) {
+          if (isAxiosError(error)) {
+            msg = `${msg}: ${error.response?.data.message}`
+          }
+          throw new Error(msg)
+        }
       }
     },
 
     revokeUserFromCredential: async (credentialId, userId) => {
-      set({ isLoading: true, error: null });
       try {
         await api.delete(
           `/clickhouse-credentials/${credentialId}/users/${userId}`
         );
         await get().fetchCredentials();
-        toast.success("User revoked from credential successfully");
       } catch (error) {
-        set({
-          error: "Failed to revoke user from credential",
-          isLoading: false,
-        });
-        toast.error("Failed to revoke user from credential");
+        let msg = "Failed to revoke user from credential"
+        if (isAxiosError(error)) {
+          if (isAxiosError(error)) {
+            msg = `${msg}: ${error.response?.data.message}`
+          }
+          throw new Error(msg)
+        }
       }
     },
 

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -68,8 +68,6 @@ export interface ClickHouseCredentialState {
   credentials: ClickHouseCredential[];
   selectedCredential: ClickHouseCredential | null;
   availableCredentials: ClickHouseCredential[];
-  isLoading: boolean;
-  error: string | null;
   fetchCredentials: () => Promise<void>;
   fetchAvailableCredentials: (organizationId: string) => Promise<void>;
   createCredential: (


### PR DESCRIPTION
I've changed a bit the pattern to handle error.
Please let me know if you like this approach, I just changed the credentials.store as an example.

The files `.store` is better to not have `toast`. 
It's better to split the view to handle the interaction with the user (dialogs, toast, etc..) and the stores only to handle the communication with the backend and save data that must to be global (like the user when logged in).

So this PR I removed some console.errors and console.log, I removed the duplication of toasts, and I moved the toast logic to the view part.

This way it will be easier as well to make automated tests.