### PR TITLE
feat: remove toast from organizations.store

### DIFF
--- a/client/src/components/AddCredentialDialog.tsx
+++ b/client/src/components/AddCredentialDialog.tsx
@@ -72,7 +72,15 @@ const AddCredentialDialog: React.FC<AddCredentialDialogProps> = ({
   const [isCredentialValid, setIsCredentialValid] = useState(false);
 
   useEffect(() => {
-    fetchOrganizations();
+    try {
+      fetchOrganizations();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message)
+      } else {
+        toast.error("Failed to fetch organizations")
+      }
+    }
   }, [fetchOrganizations]);
 
   const form = useForm<CredentialFormValues>({

--- a/client/src/components/AddOrganizationDialog.tsx
+++ b/client/src/components/AddOrganizationDialog.tsx
@@ -21,6 +21,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import useOrganizationStore from "@/stores/organization.store";
+import { toast } from "sonner";
 
 const formSchema = z.object({
   name: z
@@ -47,7 +48,16 @@ const AddOrganizationDialog: React.FC<AddOrganizationDialogProps> = ({
   });
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
-    await addOrganization(values.name);
+    try {
+      await addOrganization(values.name);
+      toast.success(`Organization ${values.name} added successfully`);
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message)
+      } else {
+        toast.error("Failed to add organization")
+      }
+    }
     form.reset();
     onClose();
   };

--- a/client/src/components/CredentialList.tsx
+++ b/client/src/components/CredentialList.tsx
@@ -13,7 +13,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
@@ -89,7 +88,15 @@ const CredentialList: React.FC<CredentialListProps> = ({
 
   useEffect(() => {
     getAllUsers();
-    fetchOrganizations();
+    try {
+      fetchOrganizations();
+    } catch (error) {
+      if (error instanceof Error) {
+        toast.error(error.message)
+      } else {
+        toast.error("Failed to fetch organizations")
+      }
+    }
     setCredentialToManage(credentials[0]);
   }, [getAllUsers, fetchOrganizations]);
 

--- a/client/src/components/OrganizationList.tsx
+++ b/client/src/components/OrganizationList.tsx
@@ -44,6 +44,7 @@ import useOrganizationStore from "@/stores/organization.store";
 import { Alert } from "./ui/alert";
 import { Organization } from "@/types/types";
 import { ScrollArea } from "@/components/ui/scroll-area";
+import { toast } from "sonner";
 
 interface OrganizationListProps {
   organizations: Organization[];
@@ -118,22 +119,40 @@ const OrganizationList: React.FC<OrganizationListProps> = ({
 
   const handleConfirmAddUser = async () => {
     if (organizationToManage && selectedUserId) {
-      await addUserToOrganization(organizationToManage._id, selectedUserId);
-      setAddUserDialogOpen(false);
-      setOrganizationToManage(null);
-      setSelectedUserId("");
+      try {
+        await addUserToOrganization(organizationToManage._id, selectedUserId);
+        setAddUserDialogOpen(false);
+        setOrganizationToManage(null);
+        setSelectedUserId("");
+        toast.success("User added to organization successfully");
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to add user to organization")
+        }
+      }
     }
   };
 
   const handleConfirmRemoveUser = async () => {
     if (organizationToManage && selectedUserId) {
-      await removeUserFromOrganization(
-        organizationToManage._id,
-        selectedUserId
-      );
-      setRemoveUserDialogOpen(false);
-      setOrganizationToManage(null);
-      setSelectedUserId("");
+      try {
+        await removeUserFromOrganization(
+          organizationToManage._id,
+          selectedUserId
+        );
+        setRemoveUserDialogOpen(false);
+        setOrganizationToManage(null);
+        setSelectedUserId("");
+        toast.success("User removed from organization successfully");
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to remove user from organization")
+        }
+      }
     }
   };
 

--- a/client/src/components/UpdateOrganizationDialog.tsx
+++ b/client/src/components/UpdateOrganizationDialog.tsx
@@ -1,5 +1,5 @@
 // src/components/UpdateOrganizationDialog.tsx
-import React from "react";
+import {useEffect} from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import * as z from "zod";
@@ -21,6 +21,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import useOrganizationStore from "@/stores/organization.store";
+import { toast } from "sonner";
 
 const formSchema = z.object({
   name: z.string().min(1, "Organization name is required"),
@@ -46,12 +47,21 @@ const UpdateOrganizationDialog: React.FC<UpdateOrganizationDialogProps> = ({
 
   const onSubmit = async (values: z.infer<typeof formSchema>) => {
     if (selectedOrganization) {
-      await updateOrganization(selectedOrganization._id, values.name);
+      try {
+        await updateOrganization(selectedOrganization._id, values.name);
+        toast.success(`Organization ${values.name} updated successfully`);
+      } catch (error) {
+        if (error instanceof Error) {
+          toast.error(error.message)
+        } else {
+          toast.error("Failed to update organization")
+        }
+      }
       onClose();
     }
   };
 
-  React.useEffect(() => {
+  useEffect(() => {
     if (selectedOrganization) {
       form.reset({ name: selectedOrganization.name });
     }

--- a/client/src/stores/clickHouseCredentials.store.ts
+++ b/client/src/stores/clickHouseCredentials.store.ts
@@ -15,7 +15,11 @@ const useClickHouseCredentialStore = create<ClickHouseCredentialState>(
         const response = await api.get("/clickhouse-credentials");
         set({ credentials: response.data });
       } catch (error) {
-        throw new Error("Failed to fetch credentials")
+        let msg = "Failed to fetch credentials";
+        if (isAxiosError(error)) {
+          msg = `${msg}: ${error.response?.data.message}`
+        }
+        throw new Error(msg)
       }
     },
     // fetch available credentials for the current user based on the organization they are in
@@ -26,7 +30,11 @@ const useClickHouseCredentialStore = create<ClickHouseCredentialState>(
         );
         set({ availableCredentials: response.data });
       } catch (error) {
-        throw new Error("Failed to fetch available credentials")
+        let msg = "Failed to fetch available credentials";
+        if (isAxiosError(error)) {
+          msg = `${msg}: ${error.response?.data.message}`
+        }
+        throw new Error(msg)
       }
     },
 

--- a/client/src/stores/organization.store.ts
+++ b/client/src/stores/organization.store.ts
@@ -1,23 +1,24 @@
 // organization store
 import { create } from "zustand";
 import api from "@/api/axios.config";
-import { toast } from "sonner";
+import { isAxiosError } from "axios";
 
 import { OrganizationState } from "@/types/types";
 
 const useOrganizationStore = create<OrganizationState>((set, get) => ({
   organizations: [],
   selectedOrganization: null,
-  isLoading: false,
-  error: null,
 
   fetchOrganizations: async () => {
-    set({ isLoading: true, error: null });
     try {
       const response = await api.get("/organizations");
-      set({ organizations: response.data, isLoading: false });
+      set({ organizations: response.data });
     } catch (error) {
-      set({ error: "Failed to fetch organizations", isLoading: false });
+      let msg = "Failed to fetch organizations";
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 
@@ -26,68 +27,70 @@ const useOrganizationStore = create<OrganizationState>((set, get) => ({
   },
 
   addOrganization: async (name) => {
-    set({ isLoading: true, error: null });
     try {
       await api.post("/organizations", { name });
       await get().fetchOrganizations();
-      toast.success(`Organization ${name} added successfully`);
     } catch (error) {
-      set({ error: "Failed to add organization", isLoading: false });
-      toast.error("Failed to add organization");
+      let msg = "Failed to add organization"
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 
   updateOrganization: async (id, name) => {
-    set({ isLoading: true, error: null });
     try {
       await api.put(`/organizations`, {
         name,
         organizationId: id,
       });
       await get().fetchOrganizations();
-      toast.success(`Organization ${name} updated successfully`);
     } catch (error) {
-      set({ error: "Failed to update organization", isLoading: false });
-      toast.error("Failed to update organization");
+      let msg = "Failed to update organization"
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 
   deleteOrganization: async (id) => {
-    set({ isLoading: true, error: null });
     try {
       await api.delete(`/organizations`, { data: { organizationId: id } });
       await get().fetchOrganizations();
-      toast.info(`Organization deleted successfully`);
     } catch (error) {
-      set({ error: "Failed to delete organization", isLoading: false });
-      toast.error("Failed to delete organization");
+      let msg = "Failed to delete organization"
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 
   addUserToOrganization: async (organizationId, userId) => {
-    set({ isLoading: true, error: null });
     try {
       await api.post(`/organizations/${organizationId}/members`, { userId });
       await get().fetchOrganizations();
-      toast.success("User added to organization successfully");
     } catch (error) {
-      set({ error: "Failed to add user to organization", isLoading: false });
-      toast.error("Failed to add user to organization");
+      let msg = "Failed to add user to organization"
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 
   removeUserFromOrganization: async (organizationId, userId) => {
-    set({ isLoading: true, error: null });
     try {
       await api.delete(`/organizations/${organizationId}/members/${userId}`);
       await get().fetchOrganizations();
-      toast.success("User removed from organization successfully");
     } catch (error) {
-      set({
-        error: "Failed to remove user from organization",
-        isLoading: false,
-      });
-      toast.error("Failed to remove user from organization");
+      let msg = "Failed to remove user from organization"
+      if (isAxiosError(error)) {
+        msg = `${msg}: ${error.response?.data.message}`
+      }
+      throw new Error(msg)
     }
   },
 }));

--- a/client/src/types/types.ts
+++ b/client/src/types/types.ts
@@ -35,8 +35,6 @@ export interface User {
 export interface OrganizationState {
   organizations: Organization[];
   selectedOrganization: Organization | null;
-  isLoading: boolean;
-  error: string | null;
   fetchOrganizations: () => Promise<void>;
   setSelectedOrganization: (organization: Organization) => void;
   addOrganization: (name: string) => Promise<void>;


### PR DESCRIPTION
Following the same pattern as the previous PR.

Moved toast to pages, removed from stores for Organizations.