### PR TITLE
add docker compose, add readme to run docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,6 @@ yarn-error.log
 # Ignore Git-specific files
 .git
 .gitignore
+
+
+.clickhouse_local_data

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,7 @@ dist-ssr
 *.sw?
 .env
 !.env.example
+
+
+# Remove some things for docker-compose
+.clickhouse_local_data

--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ docker run -p 5521:5521 \
 
 When these environment variables are set, CH-UI will automatically use them to configure the ClickHouse connection, bypassing the need for manual setup in the UI.
 
+### Using docker-compose to run a localhost clickhouse (only for development)
+
+The following command will run a clickhouse database with a connection to http://localhost:8123 and a user `dev` with password `dev`.
+The data will be persisted in this directory: `.clickhouse_local_data`
+```bash
+docker-compose -f docker-compose-dev.yml up -d
+```
+
+Use the following command to turn down, don't forget to remove `.clickhouse_local_data` if you want to save some space in your HD but then all data will be erased.
+```bash
+docker-compose -f docker-compose-dev.yml down
+```
+
 ### Prerequisites
 
 What things you need to install the software and how to install them:

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -1,0 +1,14 @@
+services:
+  clickhouse:
+    image: clickhouse/clickhouse-server
+    volumes:
+      - ./.clickhouse_local_data:/var/lib/clickhouse
+      - ./docker/dev.xml:/etc/clickhouse-server/users.d/dev.xml
+    ports:
+      - "9000:9000"
+      - "8123:8123"
+    ulimits:
+      nproc: 65535
+      nofile:
+        soft: 262144
+        hard: 262144

--- a/docker/dev.xml
+++ b/docker/dev.xml
@@ -1,0 +1,14 @@
+<clickhouse>
+    <users>
+        <dev>
+            <password>dev</password>
+
+            <networks>
+                <ip>::/0</ip>
+            </networks>
+
+            <profile>default</profile>
+            <quota>default</quota>
+        </dev>
+    </users>
+</clickhouse>


### PR DESCRIPTION
What does this PR mean?

- Add docker-compose to run Clickhouse locally;
- Update the readme file to run Clickhouse docker-compose;

I did this cause I do not have access to Clickhouse db, so this way, I can just run `docker-compose -f docker-compose-dev.yml up -d`, and then I have a Clickhouse configured locally for me. 