### PR TITLE
Gate governance background sync on Pro license

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -247,7 +247,11 @@ func (s *Server) Start() error {
 	s.scheduler.Start()
 	s.pipelineRunner.Start()
 	s.modelScheduler.Start()
-	s.govSyncer.StartBackground()
+	if s.cfg.IsPro() {
+		s.govSyncer.StartBackground()
+	} else {
+		slog.Info("Governance background sync requires Pro license, skipping")
+	}
 	s.alerts.Start()
 	s.langfuse.Start()
 


### PR DESCRIPTION
## Problem

The governance background syncer polls `system.query_log` every 5 minutes and writes every entry into a local SQLite database for lineage tracking and policy evaluation. On busy ClickHouse instances this can generate significant disk I/O — in our production deployment the SQLite DB grew to **12 GB** (17M rows, 5 indexes) on the same EBS volume as ClickHouse data, producing periodic ~1,700 IOPS spikes that competed with ClickHouse for disk bandwidth.

The governance feature is intended to be Pro-only — the UI routes are already gated behind `RequirePro` middleware in `server.go`. However, `s.govSyncer.StartBackground()` is called unconditionally, meaning installations without a Pro license still pay the I/O cost for a feature they can't access.

## Fix

Gate `StartBackground()` on `cfg.IsPro()`, consistent with how the rest of the governance feature is licensed:

```go
if s.cfg.IsPro() {
    s.govSyncer.StartBackground()
} else {
    slog.Info("Governance background sync requires Pro license, skipping")
}
```

On-demand `SyncConnection()` calls via the governance API routes remain unaffected — they're already Pro-gated via `RequirePro` middleware, so they only fire for licensed installations.

## Testing

- Built from this branch as a sidecar image in our ClickHouse pods
- Verified log message `"Governance background sync requires Pro license, skipping"` on startup
- Verified no `system.query_log` poll queries arrive at ClickHouse after the change
- Verified governance UI routes continue to return 402 Payment Required without a Pro license (unchanged behavior)