### PR TITLE
fix(ui): stop command palette infinite update loop (#129)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to CH-UI are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Command palette no longer enters an infinite Svelte update loop
+  (`effect_update_depth_exceeded`) when opened: the open routine runs `loadAll()`
+  inside `untrack()` so its writes to the databases/data stores can't re-trigger
+  the effect that started it (#129).
+- `⌘/Ctrl+K` now toggles the command palette, so pressing it again closes the
+  palette as the help text describes (#129).
+
 ## [2.5.2] - 2026-06-29
 
 ### Fixed

--- a/ui/src/lib/components/layout/CommandPalette.svelte
+++ b/ui/src/lib/components/layout/CommandPalette.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { tick, onMount } from 'svelte'
+  import { tick, onMount, untrack } from 'svelte'
   import {
     Search, Plus, Table2, Sparkles, LayoutDashboard, Bookmark, Clock,
     Brain, Shield, Settings, Moon, Sun, LogOut, SquareTerminal, Home,
@@ -526,11 +526,17 @@
 
   $effect(() => {
     if (!open) return
-    query = ''
-    selectedIdx = 0
-    scopeGroup = null
-    loadAll()
-    tick().then(() => inputEl?.focus())
+    // Run the open routine untracked: loadAll() mutates the databases/data
+    // stores, and without untrack the effect would subscribe to its own writes
+    // and re-run forever (effect_update_depth_exceeded). The only dependency we
+    // want here is `open` flipping to true.
+    untrack(() => {
+      query = ''
+      selectedIdx = 0
+      scopeGroup = null
+      loadAll()
+      tick().then(() => inputEl?.focus())
+    })
   })
 
   const scopeChip = $derived.by(() => {

--- a/ui/src/lib/components/layout/Shell.svelte
+++ b/ui/src/lib/components/layout/Shell.svelte
@@ -4,7 +4,7 @@
   import TabGroup from './TabGroup.svelte'
   import CommandPalette from './CommandPalette.svelte'
   import { getGroups, isSplit, setFocusedGroup, splitTabToSide, openQueryTab } from '../../stores/tabs.svelte'
-  import { openCommandPalette } from '../../stores/command-palette.svelte'
+  import { openCommandPalette, toggleCommandPalette } from '../../stores/command-palette.svelte'
 
   const groups = $derived(getGroups())
   const split = $derived(isSplit())
@@ -51,7 +51,7 @@
 
     if (mod && e.key.toLowerCase() === 'k') {
       e.preventDefault()
-      openCommandPalette()
+      toggleCommandPalette()
       return
     }
 


### PR DESCRIPTION
Fixes #129.

## Problem
Opening the command palette put CH-UI into an infinite Svelte reactive loop (`effect_update_depth_exceeded`). The palette became stuck — `Esc`, backdrop click, and command selection all stopped working — and the console filled with thousands of errors plus repeated `GET /api/query/tables` requests (`ERR_INSUFFICIENT_RESOURCES`).

## Root cause
The open routine:
```ts
$effect(() => {
  if (!open) return
  ...
  loadAll()          // loads databases/tables, mutates the schema store
  ...
})
```
`loadAll()` reads and **mutates** the `databases` store synchronously. Because that read happens inside the effect, the effect subscribes to its own writes, so every load re-runs the effect → another `loadAll()` → loop.

## Fix
1. Wrap the open routine in `untrack()` so `loadAll()`'s store writes no longer feed back into the effect. The only remaining dependency is `open` flipping to true — exactly the intended trigger.
2. Bind global `⌘/Ctrl+K` to `toggleCommandPalette()` instead of `openCommandPalette()`, so pressing it again closes the palette (matches the help text and the reporter's note).

## Verification
- `svelte-check`: 0 errors
- `bun run build`: succeeds

Thanks to @szymon-bwc for the precise root-cause analysis.