### PR TITLE
fix(github): recurse into subdirectories when syncing SQL models

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -117,9 +117,16 @@ func (c *Client) GetTree(owner, repo, branch string) ([]TreeEntry, error) {
 	return result.Tree, nil
 }
 
-// FilterSQLFiles returns tree entries that are .sql blobs under the given path prefix.
+// FilterSQLFiles returns tree entries that are .sql blobs under the given path
+// prefix, recursing into subdirectories. dbt projects nest models under folders
+// like models/staging/ and models/marts/, so a non-recursive scan of the
+// configured path would miss every model in a standard layout. An empty prefix
+// matches the whole repo.
 func FilterSQLFiles(entries []TreeEntry, pathPrefix string) []TreeEntry {
-	pathPrefix = strings.TrimSuffix(pathPrefix, "/") + "/"
+	pathPrefix = strings.TrimSuffix(pathPrefix, "/")
+	if pathPrefix != "" {
+		pathPrefix += "/"
+	}
 	var filtered []TreeEntry
 	for _, e := range entries {
 		if e.Type != "blob" {
@@ -129,11 +136,6 @@ func FilterSQLFiles(entries []TreeEntry, pathPrefix string) []TreeEntry {
 			continue
 		}
 		if !strings.HasSuffix(strings.ToLower(e.Path), ".sql") {
-			continue
-		}
-		// Skip files in subdirectories (only top-level .sql files in the path)
-		rel := strings.TrimPrefix(e.Path, pathPrefix)
-		if strings.Contains(rel, "/") {
 			continue
 		}
 		filtered = append(filtered, e)

--- a/internal/github/client_test.go
+++ b/internal/github/client_test.go
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// Copyright (C) 2024-2026 Caio Ricciuti.
+// Part of CH-UI Pro. Licensed under the Business Source License 1.1 (see
+// LICENSE.BSL), NOT the Apache-2.0 LICENSE that governs the rest of the repo.
+
+package github
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestFilterSQLFiles(t *testing.T) {
+	// A dbt-style nested tree plus some noise (non-sql, directory entries,
+	// a sibling path that shares a prefix).
+	tree := []TreeEntry{
+		{Path: "dbt/models", Type: "tree"},
+		{Path: "dbt/models/sources.yml", Type: "blob"},
+		{Path: "dbt/models/top_level.sql", Type: "blob"},
+		{Path: "dbt/models/staging", Type: "tree"},
+		{Path: "dbt/models/staging/stg_orders.sql", Type: "blob"},
+		{Path: "dbt/models/marts/core/fct_orders.SQL", Type: "blob"}, // deep + uppercase ext
+		{Path: "dbt/models/marts/core/schema.yml", Type: "blob"},
+		{Path: "dbt/models2/other.sql", Type: "blob"}, // sibling sharing the prefix string
+		{Path: "dbt/macros/helper.sql", Type: "blob"}, // outside the models path
+		{Path: "root.sql", Type: "blob"},
+	}
+
+	tests := []struct {
+		name   string
+		prefix string
+		want   []string
+	}{
+		{
+			name:   "recurses into subdirectories under the path",
+			prefix: "dbt/models",
+			want: []string{
+				"dbt/models/marts/core/fct_orders.SQL",
+				"dbt/models/staging/stg_orders.sql",
+				"dbt/models/top_level.sql",
+			},
+		},
+		{
+			name:   "trailing slash is equivalent",
+			prefix: "dbt/models/",
+			want: []string{
+				"dbt/models/marts/core/fct_orders.SQL",
+				"dbt/models/staging/stg_orders.sql",
+				"dbt/models/top_level.sql",
+			},
+		},
+		{
+			name:   "prefix boundary does not leak into sibling dir",
+			prefix: "dbt/macros",
+			want:   []string{"dbt/macros/helper.sql"},
+		},
+		{
+			name:   "empty prefix matches the whole repo",
+			prefix: "",
+			want: []string{
+				"dbt/macros/helper.sql",
+				"dbt/models/marts/core/fct_orders.SQL",
+				"dbt/models/staging/stg_orders.sql",
+				"dbt/models/top_level.sql",
+				"dbt/models2/other.sql",
+				"root.sql",
+			},
+		},
+		{
+			name:   "no matches under an unrelated path",
+			prefix: "nope",
+			want:   nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := paths(FilterSQLFiles(tree, tc.prefix))
+			sort.Strings(got)
+			want := append([]string(nil), tc.want...)
+			sort.Strings(want)
+			if len(got) == 0 && len(want) == 0 {
+				return
+			}
+			if !reflect.DeepEqual(got, want) {
+				t.Errorf("FilterSQLFiles(%q):\n got  %v\n want %v", tc.prefix, got, want)
+			}
+		})
+	}
+}
+
+func paths(entries []TreeEntry) []string {
+	out := make([]string, 0, len(entries))
+	for _, e := range entries {
+		out = append(out, e.Path)
+	}
+	return out
+}


### PR DESCRIPTION
## Problem

The GitHub model sync imports nothing from a standard (nested) dbt project. `FilterSQLFiles` fetches the git tree with `?recursive=1`, but then explicitly skips any `.sql` file that isn't directly in the configured path:

```go
// Skip files in subdirectories (only top-level .sql files in the path)
rel := strings.TrimPrefix(e.Path, pathPrefix)
if strings.Contains(rel, "/") { continue }
```

dbt projects nest models under `models/staging/`, `models/marts/`, etc., so pointing the sync at the models directory (or the project root) matches zero `.sql` files and the sync reports `found SQL files count=0`.

### Reproduction
1. Point a GitHub model sync at a repo whose `.sql` models live in subfolders of the configured path (e.g. dbt's `models/`, with `models/marts/*.sql`).
2. Sync.
3. Result: 0 models imported. Only a folder containing `.sql` files *directly* (a leaf) imports anything.

### Expected
`.sql` models are discovered recursively under the configured path, matching dbt's own project layout ("file-compatible with dbt-core").

## Change
- `FilterSQLFiles` now includes `.sql` blobs at any depth under the path prefix (removes the subdirectory skip).
- An empty path prefix now matches the whole repo (previously the `+ "/"` made it match nothing).
- Added `internal/github/client_test.go` with table-driven tests: recursion, trailing-slash equivalence, prefix-boundary isolation (`dbt/models` must not match `dbt/models2`), extension/blob filtering, and the root case.

Model names are still derived from the file basename (`ParseModelFile`), which is safe because dbt enforces unique model names across a project.

## Notes
- No schema or API changes.
- `go vet ./...`, `gofmt`, and `go test ./internal/github/ -race` pass.