### PR TITLE
feat(editor): show live query stats while queries are running (#147)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to CH-UI are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Live query progress in the editor** (#147): while a query runs, the result
+  panel shows elapsed time, percent complete, rows and bytes read, and read
+  throughput — the numbers ClickHouse's own `/play` reports. Progress is sampled
+  from `system.processes` (300 ms) and streamed to the browser as `progress`
+  messages on the existing NDJSON query stream. Statements that work while the
+  connection is open report progress too (`INSERT ... SELECT`, `OPTIMIZE TABLE
+  ... FINAL`); mutations still run in the background, so their readout covers
+  only the statement.
+- Finished streaming queries now report rows and bytes read. Previously only
+  elapsed time was available, because `JSONCompactEachRow` carries no
+  statistics; the numbers now come from ClickHouse's `X-ClickHouse-Summary`
+  header reconciled with the last progress sample. The readout stays in place
+  after the query ends, so a query too short to report progress still shows
+  what it read (the duplicate rows/bytes chips were dropped from the result
+  footer).
+
+### Fixed
+
+- Cancelling a query (or closing the tab) now stops it on ClickHouse. The agent
+  tags every streamed query with a `query_id`, and an abandoned stream is killed
+  with `KILL QUERY` instead of being left to run to completion unattended.
+
 ## [2.7.0] - 2026-08-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   panel shows elapsed time, percent complete, rows and bytes read, and read
   throughput — the numbers ClickHouse's own `/play` reports. Progress is sampled
   from `system.processes` (300 ms) and streamed to the browser as `progress`
-  messages on the existing NDJSON query stream. Statements that work while the
+  messages on the existing NDJSON query stream. A user without `SELECT` on
+  `system.processes` gets no live readout and no errors: the first refused
+  sample stops sampling for that query. Statements that work while the
   connection is open report progress too (`INSERT ... SELECT`, `OPTIMIZE TABLE
   ... FINAL`); mutations still run in the background, so their readout covers
   only the statement.

--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Everything below is included in the free Community edition under Apache 2.0.
 - CodeMirror 6 with SQL syntax highlighting and autocomplete
 - Query formatting and beautification
 - Streaming results via SSE — no timeout on long queries
+- **Live query progress** — elapsed time, percent complete, rows/bytes read and
+  read throughput while the query is still running (needs `SELECT` on
+  `system.processes`)
 - **Query cost estimation** — see estimated rows and parts to scan before running (like BigQuery's dry run)
 - Query profiling (pulls from `system.query_log`) with estimate vs actual accuracy comparison
 - Query plan analysis (EXPLAIN with parsed tree view)

--- a/connector/clickhouse.go
+++ b/connector/clickhouse.go
@@ -277,17 +277,185 @@ type StreamChunk struct {
 	Data json.RawMessage `json:"data"` // JSON array of arrays: [[v1,v2],[v3,v4],...]
 }
 
+// QueryProgress is a point-in-time snapshot of a running query, sampled from
+// system.processes while the query streams. Zero values mean "not reported":
+// total_rows_approx is 0 for sources ClickHouse cannot size up front.
+type QueryProgress struct {
+	ReadRows    uint64  `json:"read_rows"`
+	ReadBytes   uint64  `json:"read_bytes"`
+	TotalRows   uint64  `json:"total_rows"`
+	MemoryUsage int64   `json:"memory_usage"`
+	Elapsed     float64 `json:"elapsed"`
+}
+
+// progressPollInterval is how often system.processes is sampled for a running
+// query. Each sample is a sub-millisecond system-table read.
+const progressPollInterval = 300 * time.Millisecond
+
+// isSafeQueryID reports whether an ID can be embedded in SQL as-is. Gateway IDs
+// are UUIDs; anything else is refused rather than escaped, so the progress query
+// can never carry a payload.
+func isSafeQueryID(id string) bool {
+	if id == "" || len(id) > 64 {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '-', r == '_':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// watchProgress samples a running query's progress until ctx is cancelled,
+// calling onProgress for every snapshot that differs from the previous one.
+// Progress is best-effort: a user without access to system.processes, or a
+// balancer that routes the sample to another node, simply gets no updates.
+func (c *CHClient) watchProgress(ctx context.Context, queryID, user, password string, onProgress func(QueryProgress)) {
+	ticker := time.NewTicker(progressPollInterval)
+	defer ticker.Stop()
+
+	var last QueryProgress
+	seen := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		p, ok := c.fetchProgress(ctx, queryID, user, password)
+		if !ok {
+			// The row is gone the moment the query finishes; keep sampling in
+			// case this was a transient failure and the query is still running.
+			continue
+		}
+		if seen && p == last {
+			continue
+		}
+		last, seen = p, true
+		onProgress(p)
+	}
+}
+
+// fetchProgress reads one progress snapshot for queryID from system.processes.
+// The second return value is false when no snapshot is available (query not
+// running, no permission, sample failed).
+func (c *CHClient) fetchProgress(ctx context.Context, queryID, user, password string) (QueryProgress, bool) {
+	var p QueryProgress
+
+	sampleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	sql := "SELECT read_rows, read_bytes, total_rows_approx, memory_usage, elapsed" +
+		" FROM system.processes WHERE query_id = '" + queryID + "'"
+
+	// log_queries=0 keeps the samples out of system.query_log so progress
+	// polling does not pollute the user's own query history or insights.
+	raw, err := c.ExecuteRaw(sampleCtx, sql, user, password, "JSONCompact", map[string]string{"log_queries": "0"})
+	if err != nil {
+		return p, false
+	}
+
+	var resp struct {
+		Data [][]json.RawMessage `json:"data"`
+	}
+	if err := json.Unmarshal(raw, &resp); err != nil || len(resp.Data) == 0 || len(resp.Data[0]) < 5 {
+		return p, false
+	}
+
+	row := resp.Data[0]
+	p.ReadRows = jsonUint(row[0])
+	p.ReadBytes = jsonUint(row[1])
+	p.TotalRows = jsonUint(row[2])
+	p.MemoryUsage = int64(jsonUint(row[3]))
+	p.Elapsed = jsonFloat(row[4])
+	return p, true
+}
+
+// jsonUint parses a JSON number that ClickHouse may have quoted (UInt64 values
+// are emitted as strings to survive JSON's 53-bit integer range).
+func jsonUint(raw json.RawMessage) uint64 {
+	n, err := strconv.ParseUint(strings.Trim(string(raw), `"`), 10, 64)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+func jsonFloat(raw json.RawMessage) float64 {
+	f, err := strconv.ParseFloat(strings.Trim(string(raw), `"`), 64)
+	if err != nil {
+		return 0
+	}
+	return f
+}
+
+// KillQuery asks ClickHouse to stop a running query. Closing the HTTP request
+// is not enough on its own: a query that produces no output until it finishes
+// never writes to the socket, so it never notices the client is gone.
+func (c *CHClient) KillQuery(ctx context.Context, queryID, user, password string) error {
+	if !isSafeQueryID(queryID) {
+		return fmt.Errorf("unsafe query id")
+	}
+
+	killCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	sql := "KILL QUERY WHERE query_id = '" + queryID + "' ASYNC"
+	_, err := c.ExecuteRaw(killCtx, sql, user, password, "JSONCompact", map[string]string{"log_queries": "0"})
+	return err
+}
+
+// QuerySummary is ClickHouse's own accounting for a query, read from the
+// X-ClickHouse-Summary response header. The header is written when the response
+// headers are flushed, so it is exact for queries that produce their output at
+// the end (aggregations) and a partial snapshot for queries that stream rows.
+type QuerySummary struct {
+	ReadRows  uint64
+	ReadBytes uint64
+	ElapsedNS uint64
+}
+
+// parseSummary reads X-ClickHouse-Summary from a response header set.
+func parseSummary(h http.Header) (*QuerySummary, bool) {
+	raw := h.Get("X-ClickHouse-Summary")
+	if raw == "" {
+		return nil, false
+	}
+	var payload struct {
+		ReadRows  json.RawMessage `json:"read_rows"`
+		ReadBytes json.RawMessage `json:"read_bytes"`
+		ElapsedNS json.RawMessage `json:"elapsed_ns"`
+	}
+	if err := json.Unmarshal([]byte(raw), &payload); err != nil {
+		return nil, false
+	}
+	return &QuerySummary{
+		ReadRows:  jsonUint(payload.ReadRows),
+		ReadBytes: jsonUint(payload.ReadBytes),
+		ElapsedNS: jsonUint(payload.ElapsedNS),
+	}, true
+}
+
 // ExecuteStreaming runs a query using JSONCompactEachRow format, reading the response
 // line-by-line without buffering the entire result. It calls onMeta with column metadata,
-// then onChunk for each batch of chunkSize rows, and returns final statistics.
+// then onChunk for each batch of chunkSize rows, and returns ClickHouse's own
+// summary of the run (nil when the server did not report one).
+// When queryID is set and onProgress is non-nil, the query is tagged with that
+// query_id and onProgress receives live progress sampled from system.processes.
 func (c *CHClient) ExecuteStreaming(
 	ctx context.Context,
+	queryID string,
 	query, user, password string,
 	chunkSize int,
 	settings map[string]string,
 	onMeta func(meta json.RawMessage) error,
 	onChunk func(seq int, data json.RawMessage) error,
-) (*json.RawMessage, int64, error) {
+	onProgress func(p QueryProgress),
+) (*QuerySummary, int64, error) {
 	isWrite := isWriteQuery(query)
 	hasFormat := hasFormatClause(query)
 
@@ -334,6 +502,13 @@ func (c *CHClient) ExecuteStreaming(
 	params := url.Values{}
 	params.Set("default_format", "JSON")
 	params.Set("send_progress_in_http_headers", "0")
+	// Tagging the query lets us sample its progress from system.processes.
+	// ClickHouse reports progress as repeated HTTP header updates, which a Go
+	// client cannot read until the response ends, so sampling is what works.
+	trackProgress := onProgress != nil && isSafeQueryID(queryID)
+	if trackProgress {
+		params.Set("query_id", queryID)
+	}
 	// Pass settings as ClickHouse HTTP URL params for coarse server-side abort.
 	// max_result_rows + result_overflow_mode=break causes ClickHouse to stop at block
 	// granularity (~65k rows), preventing the server from doing unbounded work.
@@ -356,6 +531,13 @@ func (c *CHClient) ExecuteStreaming(
 	// Use a client without timeout for streaming (context controls cancellation)
 	// but share the configured transport for proper TLS and connection management.
 	streamClient := &http.Client{Transport: c.transport}
+
+	if trackProgress {
+		sampleCtx, stopSampling := context.WithCancel(ctx)
+		defer stopSampling()
+		go c.watchProgress(sampleCtx, queryID, user, password, onProgress)
+	}
+
 	resp, err := streamClient.Do(req)
 	if err != nil {
 		return nil, 0, fmt.Errorf("request failed: %w", err)
@@ -366,6 +548,11 @@ func (c *CHClient) ExecuteStreaming(
 		body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
 		return nil, 0, fmt.Errorf("ClickHouse error: %s", string(body))
 	}
+
+	// ClickHouse reports its accounting in a response header, so it is available
+	// before the body is read. Rows that stream out make it a partial snapshot;
+	// the caller reconciles it with the sampled progress.
+	summary, _ := parseSummary(resp.Header)
 
 	// Read line by line, accumulate chunks
 	scanner := bufio.NewScanner(resp.Body)
@@ -420,9 +607,7 @@ func (c *CHClient) ExecuteStreaming(
 		}
 	}
 
-	// We don't get statistics from JSONCompactEachRow format directly.
-	// Return nil stats — the server can compute elapsed time itself.
-	return nil, totalRows, nil
+	return summary, totalRows, nil
 }
 
 // TestConnection verifies connectivity and returns the ClickHouse version

--- a/connector/clickhouse.go
+++ b/connector/clickhouse.go
@@ -326,7 +326,13 @@ func (c *CHClient) watchProgress(ctx context.Context, queryID, user, password st
 		case <-ticker.C:
 		}
 
-		p, ok := c.fetchProgress(ctx, queryID, user, password)
+		p, ok, denied := c.fetchProgress(ctx, queryID, user, password)
+		if denied {
+			// The user may not read system.processes, and that will not change
+			// while this query runs. Stop sampling instead of failing three
+			// times a second for the rest of the query.
+			return
+		}
 		if !ok {
 			// The row is gone the moment the query finishes; keep sampling in
 			// case this was a transient failure and the query is still running.
@@ -341,9 +347,10 @@ func (c *CHClient) watchProgress(ctx context.Context, queryID, user, password st
 }
 
 // fetchProgress reads one progress snapshot for queryID from system.processes.
-// The second return value is false when no snapshot is available (query not
-// running, no permission, sample failed).
-func (c *CHClient) fetchProgress(ctx context.Context, queryID, user, password string) (QueryProgress, bool) {
+// The second return value is false when no snapshot is available (the query is
+// not running any more, or the sample failed). The third is true when the
+// server refused the read, which no amount of retrying will fix.
+func (c *CHClient) fetchProgress(ctx context.Context, queryID, user, password string) (QueryProgress, bool, bool) {
 	var p QueryProgress
 
 	sampleCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
@@ -356,14 +363,14 @@ func (c *CHClient) fetchProgress(ctx context.Context, queryID, user, password st
 	// polling does not pollute the user's own query history or insights.
 	raw, err := c.ExecuteRaw(sampleCtx, sql, user, password, "JSONCompact", map[string]string{"log_queries": "0"})
 	if err != nil {
-		return p, false
+		return p, false, isProgressDenied(err)
 	}
 
 	var resp struct {
 		Data [][]json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(raw, &resp); err != nil || len(resp.Data) == 0 || len(resp.Data[0]) < 5 {
-		return p, false
+		return p, false, false
 	}
 
 	row := resp.Data[0]
@@ -372,7 +379,32 @@ func (c *CHClient) fetchProgress(ctx context.Context, queryID, user, password st
 	p.TotalRows = jsonUint(row[2])
 	p.MemoryUsage = int64(jsonUint(row[3]))
 	p.Elapsed = jsonFloat(row[4])
-	return p, true
+	return p, true, false
+}
+
+// isProgressDenied reports whether ClickHouse refused the progress read for a
+// reason that will not change mid-query: the user lacks the grant on
+// system.processes, or the table is not exposed at all. Anything else (a
+// dropped connection, a timeout) is treated as transient and retried.
+func isProgressDenied(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, marker := range []string{
+		"ACCESS_DENIED",
+		"Not enough privileges",
+		"NOT_ENOUGH_PRIVILEGES",
+		"UNKNOWN_TABLE",
+		"UNKNOWN_DATABASE",
+		"readonly mode",
+		"READONLY",
+	} {
+		if strings.Contains(msg, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // jsonUint parses a JSON number that ClickHouse may have quoted (UInt64 values

--- a/connector/connector.go
+++ b/connector/connector.go
@@ -40,6 +40,19 @@ type Connector struct {
 
 	// Reconnection
 	reconnectDelay time.Duration
+
+	// In-flight streaming queries, so a cancel from the server can stop the
+	// query on ClickHouse instead of leaving it running unattended.
+	streamsMu sync.Mutex
+	streams   map[string]*inFlightStream
+}
+
+// inFlightStream tracks what is needed to stop a streaming query: the context
+// that aborts the local HTTP read, plus the credentials to issue KILL QUERY.
+type inFlightStream struct {
+	cancel   context.CancelFunc
+	user     string
+	password string
 }
 
 // New creates a new Connector instance
@@ -51,6 +64,7 @@ func New(cfg *config.Config, u *ui.UI) *Connector {
 		ui:             u,
 		chClient:       NewCHClient(cfg.ClickHouseURL, cfg.InsecureSkipVerify),
 		reconnectDelay: cfg.ReconnectDelay,
+		streams:        make(map[string]*inFlightStream),
 		ctx:            ctx,
 		cancel:         cancel,
 		done:           make(chan struct{}),
@@ -302,7 +316,7 @@ func (c *Connector) handleMessage(msg GatewayMessage) {
 		go c.testConnection(msg)
 
 	case MsgTypeCancelQuery:
-		c.ui.Debug("Cancel query requested for %s (not implemented)", msg.QueryID)
+		c.cancelStream(msg.QueryID)
 
 	default:
 		c.ui.Debug("Unknown message type: %s", msg.Type)
@@ -377,12 +391,53 @@ func (c *Connector) executeQuery(msg GatewayMessage) {
 	})
 }
 
+// registerStream stores the cancel function of a streaming query and returns a
+// context that is cancelled when the server abandons the query.
+func (c *Connector) registerStream(queryID, user, password string) (context.Context, func()) {
+	ctx, cancel := context.WithCancel(c.ctx)
+
+	c.streamsMu.Lock()
+	c.streams[queryID] = &inFlightStream{cancel: cancel, user: user, password: password}
+	c.streamsMu.Unlock()
+
+	return ctx, func() {
+		c.streamsMu.Lock()
+		delete(c.streams, queryID)
+		c.streamsMu.Unlock()
+		cancel()
+	}
+}
+
+// cancelStream stops an in-flight streaming query: it aborts the local read and
+// asks ClickHouse to kill the query, which also ends progress sampling.
+func (c *Connector) cancelStream(queryID string) {
+	c.streamsMu.Lock()
+	stream, ok := c.streams[queryID]
+	delete(c.streams, queryID)
+	c.streamsMu.Unlock()
+
+	if !ok {
+		c.ui.Debug("Cancel for unknown query %s (already finished)", queryID)
+		return
+	}
+
+	c.ui.Debug("Cancelling query %s", queryID)
+	stream.cancel()
+
+	if err := c.chClient.KillQuery(c.ctx, queryID, stream.user, stream.password); err != nil {
+		c.ui.Debug("KILL QUERY for %s failed: %v", queryID, err)
+	}
+}
+
 func (c *Connector) executeStreamQuery(msg GatewayMessage) {
 	start := time.Now()
 	queryID := msg.QueryID
 	sql := msg.Query
 
 	c.ui.Debug("Stream query %s: %s", queryID, truncateStr(sql, 80))
+
+	queryCtx, releaseStream := c.registerStream(queryID, msg.User, msg.Password)
+	defer releaseStream()
 
 	// Send chunks as they arrive
 	onMeta := func(meta json.RawMessage) error {
@@ -402,10 +457,34 @@ func (c *Connector) executeStreamQuery(msg GatewayMessage) {
 		})
 	}
 
-	_, totalRows, err := c.chClient.ExecuteStreaming(c.ctx, sql, msg.User, msg.Password, 5000, msg.Settings, onMeta, onChunk)
+	// Progress is sampled on a background goroutine; the last snapshot also
+	// supplies the rows/bytes read reported when the stream ends.
+	var progressMu sync.Mutex
+	var lastProgress QueryProgress
+	onProgress := func(p QueryProgress) {
+		progressMu.Lock()
+		lastProgress = p
+		progressMu.Unlock()
+
+		snapshot := p
+		if err := c.send(AgentMessage{
+			Type:     MsgTypeQueryStreamProgress,
+			QueryID:  queryID,
+			Progress: &snapshot,
+		}); err != nil {
+			c.ui.Debug("Failed to send progress for %s: %v", queryID, err)
+		}
+	}
+
+	summary, totalRows, err := c.chClient.ExecuteStreaming(queryCtx, queryID, sql, msg.User, msg.Password, 5000, msg.Settings, onMeta, onChunk, onProgress)
 	elapsed := time.Since(start)
 
 	if err != nil {
+		// A cancelled query is expected, not a failure to report back.
+		if queryCtx.Err() != nil {
+			c.ui.Debug("Stream query %s cancelled after %s", queryID, elapsed)
+			return
+		}
 		c.ui.QueryError(queryID, err)
 		c.send(AgentMessage{
 			Type:    MsgTypeQueryStreamError,
@@ -419,12 +498,31 @@ func (c *Connector) executeStreamQuery(msg GatewayMessage) {
 	c.lastQueryTime.Store(time.Now().UnixNano())
 	c.ui.QueryLog(queryID, elapsed, int(totalRows))
 
+	progressMu.Lock()
+	final := lastProgress
+	progressMu.Unlock()
+
+	// Both numbers are snapshots of counters that only grow, so the larger one
+	// is the later one: the summary header is exact for queries that emit their
+	// output at the end, the last sample is closer for queries that stream rows.
+	rowsRead, bytesRead := final.ReadRows, final.ReadBytes
+	if summary != nil {
+		if summary.ReadRows > rowsRead {
+			rowsRead = summary.ReadRows
+		}
+		if summary.ReadBytes > bytesRead {
+			bytesRead = summary.ReadBytes
+		}
+	}
+
 	c.send(AgentMessage{
 		Type:      MsgTypeQueryStreamEnd,
 		QueryID:   queryID,
 		TotalRows: totalRows,
 		Stats: &QueryStats{
-			Elapsed: elapsed.Seconds(),
+			Elapsed:   elapsed.Seconds(),
+			RowsRead:  rowsRead,
+			BytesRead: bytesRead,
 		},
 	})
 }

--- a/connector/progress_test.go
+++ b/connector/progress_test.go
@@ -3,6 +3,7 @@ package connector
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
@@ -83,9 +84,12 @@ func TestFetchProgress(t *testing.T) {
 	defer srv.Close()
 
 	c := NewCHClient(srv.URL, false)
-	p, ok := c.fetchProgress(context.Background(), "abc-123", "default", "")
+	p, ok, denied := c.fetchProgress(context.Background(), "abc-123", "default", "")
 	if !ok {
 		t.Fatal("expected a progress snapshot")
+	}
+	if denied {
+		t.Error("a successful sample must not report a denial")
 	}
 	want := QueryProgress{ReadRows: 1024, ReadBytes: 8192, TotalRows: 4096, MemoryUsage: 512, Elapsed: 1.25}
 	if p != want {
@@ -103,8 +107,12 @@ func TestFetchProgressNoRunningQuery(t *testing.T) {
 	defer srv.Close()
 
 	c := NewCHClient(srv.URL, false)
-	if _, ok := c.fetchProgress(context.Background(), "gone", "default", ""); ok {
+	_, ok, denied := c.fetchProgress(context.Background(), "gone", "default", "")
+	if ok {
 		t.Error("expected no snapshot when the query is not running")
+	}
+	if denied {
+		t.Error("a finished query is not a permission problem — sampling must keep going")
 	}
 }
 
@@ -117,8 +125,100 @@ func TestFetchProgressDeniedIsSilent(t *testing.T) {
 	defer srv.Close()
 
 	c := NewCHClient(srv.URL, false)
-	if _, ok := c.fetchProgress(context.Background(), "denied", "reader", ""); ok {
+	_, ok, denied := c.fetchProgress(context.Background(), "denied", "reader", "")
+	if ok {
 		t.Error("expected no snapshot when system.processes is denied")
+	}
+	if !denied {
+		t.Error("a privilege error must be reported as denied so sampling stops")
+	}
+}
+
+func TestIsProgressDenied(t *testing.T) {
+	denied := []string{
+		"ClickHouse error: Code: 497. DB::Exception: u: Not enough privileges. (ACCESS_DENIED)",
+		"ClickHouse error: Code: 60. DB::Exception: Unknown table system.processes. (UNKNOWN_TABLE)",
+		"ClickHouse error: Code: 164. DB::Exception: Cannot modify 'log_queries' setting in readonly mode. (READONLY)",
+	}
+	for _, msg := range denied {
+		if !isProgressDenied(errors.New(msg)) {
+			t.Errorf("expected denial for %q", msg)
+		}
+	}
+
+	transient := []string{
+		"request failed: dial tcp 127.0.0.1:8123: connect: connection refused",
+		"request failed: context deadline exceeded",
+		"failed to read response: unexpected EOF",
+	}
+	for _, msg := range transient {
+		if isProgressDenied(errors.New(msg)) {
+			t.Errorf("expected retry for %q", msg)
+		}
+	}
+	if isProgressDenied(nil) {
+		t.Error("nil error is not a denial")
+	}
+}
+
+func TestExecuteStreamingStopsSamplingWhenDenied(t *testing.T) {
+	var mu sync.Mutex
+	samples := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		query := string(body)
+
+		switch {
+		case strings.Contains(query, "system.processes"):
+			mu.Lock()
+			samples++
+			mu.Unlock()
+			w.WriteHeader(http.StatusForbidden)
+			w.Write([]byte("Code: 497. DB::Exception: reader: Not enough privileges. (ACCESS_DENIED)"))
+
+		case strings.Contains(query, "LIMIT 0"):
+			w.Write([]byte(`{"meta":[{"name":"number","type":"UInt64"}],"data":[],"rows":0}`))
+
+		default:
+			flusher := w.(http.Flusher)
+			w.Write([]byte("[1]\n"))
+			flusher.Flush()
+			// Long enough for several sampling intervals to elapse.
+			time.Sleep(1500 * time.Millisecond)
+		}
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+
+	var progressCalls int
+	_, rows, err := c.ExecuteStreaming(
+		context.Background(),
+		"stream-denied",
+		"SELECT number FROM numbers(1)",
+		"reader", "",
+		1,
+		nil,
+		func(json.RawMessage) error { return nil },
+		func(int, json.RawMessage) error { return nil },
+		func(QueryProgress) { progressCalls++ },
+	)
+	if err != nil {
+		t.Fatalf("a denied progress read must not fail the query: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows = %d, want 1", rows)
+	}
+	if progressCalls != 0 {
+		t.Errorf("progress callbacks = %d, want 0", progressCalls)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if samples != 1 {
+		t.Errorf("sampled system.processes %d times, want exactly 1 before giving up", samples)
 	}
 }
 

--- a/connector/progress_test.go
+++ b/connector/progress_test.go
@@ -1,0 +1,242 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIsSafeQueryID(t *testing.T) {
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{"3f2a1c8e-0b4d-4e7a-9c11-8d2f6a5b1e90", true},
+		{"ch_ui-stream-1", true},
+		{"", false},
+		{"' OR 1=1 --", false},
+		{"id with space", false},
+		{"id'; SELECT 1", false},
+		{strings.Repeat("a", 65), false},
+	}
+	for _, tt := range tests {
+		if got := isSafeQueryID(tt.id); got != tt.want {
+			t.Errorf("isSafeQueryID(%q) = %v, want %v", tt.id, got, tt.want)
+		}
+	}
+}
+
+func TestJSONNumberHelpers(t *testing.T) {
+	// ClickHouse quotes UInt64 values; both forms must parse.
+	if got := jsonUint(json.RawMessage(`"18446744073709551615"`)); got != 18446744073709551615 {
+		t.Errorf("jsonUint quoted = %d", got)
+	}
+	if got := jsonUint(json.RawMessage(`42`)); got != 42 {
+		t.Errorf("jsonUint bare = %d", got)
+	}
+	if got := jsonUint(json.RawMessage(`null`)); got != 0 {
+		t.Errorf("jsonUint invalid = %d, want 0", got)
+	}
+	if got := jsonFloat(json.RawMessage(`1.5`)); got != 1.5 {
+		t.Errorf("jsonFloat = %v", got)
+	}
+	if got := jsonFloat(json.RawMessage(`"oops"`)); got != 0 {
+		t.Errorf("jsonFloat invalid = %v, want 0", got)
+	}
+}
+
+func TestParseSummary(t *testing.T) {
+	h := http.Header{}
+	if _, ok := parseSummary(h); ok {
+		t.Fatal("expected no summary for empty header")
+	}
+
+	h.Set("X-ClickHouse-Summary", `{"read_rows":"3000000000","read_bytes":"24000000000","elapsed_ns":"210233459"}`)
+	s, ok := parseSummary(h)
+	if !ok {
+		t.Fatal("expected summary")
+	}
+	if s.ReadRows != 3_000_000_000 || s.ReadBytes != 24_000_000_000 || s.ElapsedNS != 210_233_459 {
+		t.Errorf("unexpected summary: %+v", s)
+	}
+
+	h.Set("X-ClickHouse-Summary", "not json")
+	if _, ok := parseSummary(h); ok {
+		t.Fatal("expected malformed summary to be ignored")
+	}
+}
+
+func TestFetchProgress(t *testing.T) {
+	var gotQuery string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		gotQuery = string(body)
+		w.Write([]byte(`{"meta":[],"data":[["1024","8192","4096","512","1.25"]],"rows":1}`))
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+	p, ok := c.fetchProgress(context.Background(), "abc-123", "default", "")
+	if !ok {
+		t.Fatal("expected a progress snapshot")
+	}
+	want := QueryProgress{ReadRows: 1024, ReadBytes: 8192, TotalRows: 4096, MemoryUsage: 512, Elapsed: 1.25}
+	if p != want {
+		t.Errorf("progress = %+v, want %+v", p, want)
+	}
+	if !strings.Contains(gotQuery, "system.processes") || !strings.Contains(gotQuery, "'abc-123'") {
+		t.Errorf("unexpected progress query: %s", gotQuery)
+	}
+}
+
+func TestFetchProgressNoRunningQuery(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"meta":[],"data":[],"rows":0}`))
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+	if _, ok := c.fetchProgress(context.Background(), "gone", "default", ""); ok {
+		t.Error("expected no snapshot when the query is not running")
+	}
+}
+
+func TestFetchProgressDeniedIsSilent(t *testing.T) {
+	// A user without access to system.processes must not break the stream.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		w.Write([]byte("Code: 497. DB::Exception: Not enough privileges."))
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+	if _, ok := c.fetchProgress(context.Background(), "denied", "reader", ""); ok {
+		t.Error("expected no snapshot when system.processes is denied")
+	}
+}
+
+func TestExecuteStreamingReportsProgress(t *testing.T) {
+	var mu sync.Mutex
+	sampled := 0
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		query := string(body)
+
+		switch {
+		case strings.Contains(query, "system.processes"):
+			mu.Lock()
+			sampled++
+			n := sampled
+			mu.Unlock()
+			w.Write([]byte(`{"meta":[],"data":[["` +
+				strconv.Itoa(n*1000) + `","` + strconv.Itoa(n*8000) + `","10000","0","0.5"]],"rows":1}`))
+
+		case strings.Contains(query, "LIMIT 0"):
+			w.Write([]byte(`{"meta":[{"name":"number","type":"UInt64"}],"data":[],"rows":0}`))
+
+		default:
+			if r.URL.Query().Get("query_id") == "" {
+				t.Error("expected the streamed query to be tagged with a query_id")
+			}
+			w.Header().Set("X-ClickHouse-Summary", `{"read_rows":"10000","read_bytes":"80000","elapsed_ns":"1000"}`)
+			flusher := w.(http.Flusher)
+			w.Write([]byte("[1]\n"))
+			flusher.Flush()
+			// Hold the response open long enough for a few progress samples.
+			time.Sleep(900 * time.Millisecond)
+			w.Write([]byte("[2]\n"))
+		}
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+
+	var progressMu sync.Mutex
+	var snapshots []QueryProgress
+
+	summary, rows, err := c.ExecuteStreaming(
+		context.Background(),
+		"stream-1",
+		"SELECT number FROM numbers(2)",
+		"default", "",
+		1,
+		nil,
+		func(json.RawMessage) error { return nil },
+		func(int, json.RawMessage) error { return nil },
+		func(p QueryProgress) {
+			progressMu.Lock()
+			snapshots = append(snapshots, p)
+			progressMu.Unlock()
+		},
+	)
+	if err != nil {
+		t.Fatalf("ExecuteStreaming: %v", err)
+	}
+	if rows != 2 {
+		t.Errorf("rows = %d, want 2", rows)
+	}
+
+	progressMu.Lock()
+	defer progressMu.Unlock()
+	if len(snapshots) == 0 {
+		t.Fatal("expected at least one progress snapshot")
+	}
+	first := snapshots[0]
+	if first.ReadRows == 0 || first.TotalRows != 10000 {
+		t.Errorf("unexpected first snapshot: %+v", first)
+	}
+
+	if summary == nil {
+		t.Fatal("expected the ClickHouse summary header to be parsed")
+	}
+	if summary.ReadRows != 10000 || summary.ReadBytes != 80000 {
+		t.Errorf("unexpected summary: %+v", summary)
+	}
+}
+
+func TestExecuteStreamingWithoutProgressCallbackIsUntagged(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := make([]byte, r.ContentLength)
+		r.Body.Read(body)
+		if strings.Contains(string(body), "system.processes") {
+			t.Error("progress must not be sampled without an onProgress callback")
+		}
+		if strings.Contains(string(body), "LIMIT 0") {
+			w.Write([]byte(`{"meta":[{"name":"number","type":"UInt64"}],"data":[],"rows":0}`))
+			return
+		}
+		if r.URL.Query().Get("query_id") != "" {
+			t.Error("query_id must not be set when progress is not tracked")
+		}
+		w.Write([]byte("[1]\n"))
+	}))
+	defer srv.Close()
+
+	c := NewCHClient(srv.URL, false)
+	_, rows, err := c.ExecuteStreaming(
+		context.Background(),
+		"stream-2",
+		"SELECT number FROM numbers(1)",
+		"default", "",
+		1,
+		nil,
+		func(json.RawMessage) error { return nil },
+		func(int, json.RawMessage) error { return nil },
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("ExecuteStreaming: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("rows = %d, want 1", rows)
+	}
+}

--- a/connector/protocol.go
+++ b/connector/protocol.go
@@ -28,6 +28,8 @@ type AgentMessage struct {
 	HostInfo  *HostInfo   `json:"host_info,omitempty"`  // Host machine metrics
 	Seq       int         `json:"seq,omitempty"`        // Chunk sequence number (for streaming)
 	TotalRows int64       `json:"total_rows,omitempty"` // Total row count (for streaming)
+
+	Progress *QueryProgress `json:"progress,omitempty"` // Live progress of a running query (for streaming)
 }
 
 // QueryStats contains query execution statistics
@@ -58,6 +60,9 @@ const (
 	MsgTypeHostInfo         = "host_info"
 	MsgTypeQueryStreamStart = "query_stream_start"
 	MsgTypeQueryStreamChunk = "query_stream_chunk"
-	MsgTypeQueryStreamEnd   = "query_stream_end"
-	MsgTypeQueryStreamError = "query_stream_error"
+	// MsgTypeQueryStreamProgress carries a progress snapshot of a query that is
+	// still running, so the UI can show rows read and throughput live.
+	MsgTypeQueryStreamProgress = "query_stream_progress"
+	MsgTypeQueryStreamEnd      = "query_stream_end"
+	MsgTypeQueryStreamError    = "query_stream_error"
 )

--- a/docs/connecting-to-clickhouse.md
+++ b/docs/connecting-to-clickhouse.md
@@ -75,8 +75,8 @@ exception — ClickHouse accepts the statement and runs the mutation in the
 background, so the readout covers only the statement itself; follow the mutation
 in `system.mutations`.
 
-The grant is optional. Without it the samples fail, the progress readout stays
-empty, and queries run exactly as before — the final row count, elapsed time and
+The grant is optional. Without it the first sample is refused, sampling stops
+for that query, the live readout stays empty, and queries run exactly as before — the final row count, elapsed time and
 rows/bytes read still come from ClickHouse's response summary. The samples are
 run with `log_queries=0`, so they never appear in `system.query_log`, query
 history or Query Insights.

--- a/docs/connecting-to-clickhouse.md
+++ b/docs/connecting-to-clickhouse.md
@@ -55,3 +55,32 @@ outbound WebSocket to the CH-UI server. See the
 
 Both are first-class — the tunnel is a zero-exposure convenience, not a sign that
 the reverse-proxy model is unsupported.
+
+## ClickHouse grants used by the editor
+
+The editor shows live progress for a running query — elapsed time, percent
+complete, rows and bytes read, read throughput — and keeps the readout with the
+final numbers once the query finishes. The numbers are sampled from
+`system.processes` every 300 ms by the agent, using the credentials of the
+signed-in user:
+
+```sql
+GRANT SELECT ON system.processes TO your_user;
+```
+
+Progress is not limited to `SELECT`: statements that do their work while the
+connection is open report it too, such as `INSERT ... SELECT` and `OPTIMIZE
+TABLE ... FINAL`. Mutations (`ALTER TABLE ... UPDATE`/`DELETE`) are the
+exception — ClickHouse accepts the statement and runs the mutation in the
+background, so the readout covers only the statement itself; follow the mutation
+in `system.mutations`.
+
+The grant is optional. Without it the samples fail, the progress readout stays
+empty, and queries run exactly as before — the final row count, elapsed time and
+rows/bytes read still come from ClickHouse's response summary. The samples are
+run with `log_queries=0`, so they never appear in `system.query_log`, query
+history or Query Insights.
+
+Cancelling a query in the editor issues `KILL QUERY` for that query's
+`query_id`. A user can always kill their own queries, so no extra grant is
+needed.

--- a/internal/server/handlers/query.go
+++ b/internal/server/handlers/query.go
@@ -860,6 +860,15 @@ func (h *QueryHandler) StreamQuery(w http.ResponseWriter, r *http.Request) {
 	}
 	defer h.Gateway.CleanupStream(session.ConnectionID, requestID)
 
+	// The browser aborts the fetch when the user cancels a query or closes the
+	// tab. Tell the agent so ClickHouse stops working on a result nobody wants.
+	streamFinished := false
+	defer func() {
+		if !streamFinished {
+			h.Gateway.CancelStreamQuery(session.ConnectionID, requestID)
+		}
+	}()
+
 	// Record exactly one history entry per dispatched query. The deferred call
 	// covers client disconnects (ctx.Done) — the query still ran on ClickHouse,
 	// and a cancelled long query is exactly what users look for in history.
@@ -895,7 +904,9 @@ func (h *QueryHandler) StreamQuery(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Read chunks until channel is closed or client disconnects
+	// Read chunks until channel is closed or client disconnects. Progress
+	// snapshots are interleaved so a query that emits no rows until it finishes
+	// still reports rows read and throughput while it runs.
 	seq := 0
 	for {
 		select {
@@ -906,6 +917,9 @@ func (h *QueryHandler) StreamQuery(w http.ResponseWriter, r *http.Request) {
 			enc.Encode(map[string]interface{}{"type": "chunk", "data": chunk, "seq": seq})
 			flusher.Flush()
 			seq++
+		case progress := <-stream.ProgressCh:
+			enc.Encode(map[string]interface{}{"type": "progress", "progress": progress})
+			flusher.Flush()
 		case <-ctx.Done():
 			return
 		}
@@ -915,6 +929,7 @@ streamDone:
 	// ChunkCh closed — read final done or error
 	select {
 	case donePayload := <-stream.DoneCh:
+		streamFinished = true
 		var done tunnel.StreamDone
 		json.Unmarshal(donePayload, &done)
 		enc.Encode(map[string]interface{}{
@@ -925,6 +940,7 @@ streamDone:
 		flusher.Flush()
 		recordHistory("success", "", done.TotalRows)
 	case err := <-stream.ErrorCh:
+		streamFinished = true
 		enc.Encode(map[string]interface{}{"type": "error", "error": err.Error()})
 		flusher.Flush()
 		recordHistory("error", err.Error(), 0)

--- a/internal/tunnel/api.go
+++ b/internal/tunnel/api.go
@@ -3,6 +3,7 @@ package tunnel
 import (
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"time"
 
 	"github.com/google/uuid"
@@ -178,10 +179,11 @@ func (g *Gateway) ExecuteStreamQuery(connectionID, sql, user, password string, s
 
 	requestID = uuid.NewString()
 	stream = &PendingStreamRequest{
-		MetaCh:  make(chan json.RawMessage, 1),
-		ChunkCh: make(chan json.RawMessage, 8),
-		DoneCh:  make(chan json.RawMessage, 1),
-		ErrorCh: make(chan error, 1),
+		MetaCh:     make(chan json.RawMessage, 1),
+		ChunkCh:    make(chan json.RawMessage, 8),
+		ProgressCh: make(chan json.RawMessage, 1),
+		DoneCh:     make(chan json.RawMessage, 1),
+		ErrorCh:    make(chan error, 1),
 	}
 	t.Pending.Store(requestID, stream)
 
@@ -206,6 +208,29 @@ func (g *Gateway) ExecuteStreamQuery(connectionID, sql, user, password string, s
 	}
 
 	return requestID, stream, nil
+}
+
+// CancelStreamQuery tells the agent to abort a streaming query it is still
+// running, so a query the user cancelled stops consuming ClickHouse resources.
+func (g *Gateway) CancelStreamQuery(connectionID, requestID string) {
+	val, ok := g.tunnels.Load(connectionID)
+	if !ok {
+		return
+	}
+	t := val.(*ConnectedTunnel)
+
+	data, _ := json.Marshal(GatewayMessage{
+		Type:    "cancel_query",
+		ID:      requestID,
+		QueryID: requestID,
+	})
+
+	t.mu.Lock()
+	err := t.WS.WriteMessage(websocket.TextMessage, data)
+	t.mu.Unlock()
+	if err != nil {
+		slog.Debug("Failed to send query cancellation", "request_id", requestID, "error", err)
+	}
 }
 
 // CleanupStream removes a pending stream request from the tunnel's pending map.

--- a/internal/tunnel/gateway.go
+++ b/internal/tunnel/gateway.go
@@ -82,10 +82,11 @@ type PendingRequest struct {
 
 // PendingStreamRequest represents a streaming query waiting for chunked responses.
 type PendingStreamRequest struct {
-	MetaCh  chan json.RawMessage // receives query_stream_start meta
-	ChunkCh chan json.RawMessage // receives query_stream_chunk data (buffered)
-	DoneCh  chan json.RawMessage // receives query_stream_end statistics
-	ErrorCh chan error
+	MetaCh     chan json.RawMessage // receives query_stream_start meta
+	ChunkCh    chan json.RawMessage // receives query_stream_chunk data (buffered)
+	ProgressCh chan json.RawMessage // receives query_stream_progress snapshots (latest wins)
+	DoneCh     chan json.RawMessage // receives query_stream_end statistics
+	ErrorCh    chan error
 }
 
 // ConnectedTunnel represents an active tunnel agent connection.
@@ -209,6 +210,9 @@ func (g *Gateway) readLoop(conn *websocket.Conn) {
 
 		case "query_stream_chunk":
 			g.handleStreamChunk(connID, &msg)
+
+		case "query_stream_progress":
+			g.handleStreamProgress(connID, &msg)
 
 		case "query_stream_end":
 			g.handleStreamEnd(connID, &msg)
@@ -474,6 +478,45 @@ func (g *Gateway) handleStreamChunk(connID string, msg *AgentMessage) {
 	}
 
 	pending.ChunkCh <- msg.Data // backpressure: blocks if consumer is slow
+}
+
+// handleStreamProgress forwards a progress snapshot to the waiting HTTP handler.
+// Snapshots are disposable: if the consumer has not picked up the previous one,
+// it is dropped so a slow reader can never stall the agent's socket.
+func (g *Gateway) handleStreamProgress(connID string, msg *AgentMessage) {
+	id := msg.GetMessageID()
+	if connID == "" || id == "" || len(msg.Progress) == 0 {
+		return
+	}
+
+	val, ok := g.tunnels.Load(connID)
+	if !ok {
+		return
+	}
+	t := val.(*ConnectedTunnel)
+
+	pendingVal, ok := t.Pending.Load(id)
+	if !ok {
+		return
+	}
+	pending, ok := pendingVal.(*PendingStreamRequest)
+	if !ok || pending.ProgressCh == nil {
+		return
+	}
+
+	select {
+	case pending.ProgressCh <- msg.Progress:
+	default:
+		// Replace the stale snapshot with this newer one when possible.
+		select {
+		case <-pending.ProgressCh:
+		default:
+		}
+		select {
+		case pending.ProgressCh <- msg.Progress:
+		default:
+		}
+	}
 }
 
 func (g *Gateway) handleStreamEnd(connID string, msg *AgentMessage) {

--- a/internal/tunnel/protocol.go
+++ b/internal/tunnel/protocol.go
@@ -20,6 +20,7 @@ type AgentMessage struct {
 	HostInfo   json.RawMessage `json:"host_info,omitempty"`  // host_info
 	Seq        int             `json:"seq,omitempty"`        // query_stream_chunk sequence number
 	TotalRows  int64           `json:"total_rows,omitempty"` // query_stream_end total row count
+	Progress   json.RawMessage `json:"progress,omitempty"`   // query_stream_progress snapshot
 }
 
 // GetMessageID returns the message ID from either legacy or Go agent format.

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -430,3 +430,26 @@ pre,
   .prose-panel em { @apply italic; }
   .prose-panel img { @apply rounded-lg max-w-full my-2; }
 }
+
+/* Indeterminate query-progress sweep: used while a running query reports no
+   total row estimate, so the bar cannot show a real percentage. */
+@keyframes query-sweep {
+  0% {
+    transform: translateX(-100%);
+  }
+  100% {
+    transform: translateX(400%);
+  }
+}
+
+.animate-query-sweep {
+  animation: query-sweep 1.4s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .animate-query-sweep {
+    animation: none;
+    width: 100%;
+    opacity: 0.5;
+  }
+}

--- a/ui/src/lib/api/stream.ts
+++ b/ui/src/lib/api/stream.ts
@@ -1,5 +1,5 @@
 import { withBase } from '../basePath'
-import type { ColumnMeta, QueryStats, StreamMessage } from '../types/query'
+import type { ColumnMeta, QueryProgress, QueryStats, StreamMessage } from '../types/query'
 import { safeParse } from '../utils/safe-json'
 
 /** Execute a streaming query via NDJSON. Calls the provided callbacks as data arrives. */
@@ -12,6 +12,7 @@ export async function executeStreamQuery(
   onError: (error: string) => void,
   signal?: AbortSignal,
   params?: Record<string, string>,
+  onProgress?: (progress: QueryProgress) => void,
 ): Promise<void> {
   const res = await fetch(withBase('/api/query/stream'), {
     method: 'POST',
@@ -49,6 +50,9 @@ export async function executeStreamQuery(
             break
           case 'chunk':
             onChunk(msg.data, msg.seq)
+            break
+          case 'progress':
+            onProgress?.(msg.progress)
             break
           case 'done':
             onDone(msg.statistics, msg.total_rows)

--- a/ui/src/lib/components/editor/QueryProgressBar.svelte
+++ b/ui/src/lib/components/editor/QueryProgressBar.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+  import type { QueryProgress, QueryStats } from '../../types/query'
+  import { formatBytes, formatCompactNumber } from '../../utils/format'
+
+  interface Props {
+    /** Latest snapshot from the server; null until the first one arrives. */
+    progress: QueryProgress | null
+    /** Wall-clock start of the run, used to keep the timer smooth. */
+    startedAt: number | null
+    /** The query is still executing. */
+    running?: boolean
+    /** ClickHouse's accounting for a finished query. */
+    stats?: QueryStats | null
+    /** Client-measured duration of a finished run, in milliseconds. */
+    elapsedMs?: number
+  }
+
+  let { progress, startedAt, running = false, stats = null, elapsedMs = 0 }: Props = $props()
+
+  // Elapsed ticks locally while the query runs so the timer moves between
+  // snapshots; a finished run shows its measured duration instead.
+  let now = $state(Date.now())
+  $effect(() => {
+    if (!running) return
+    const timer = setInterval(() => (now = Date.now()), 100)
+    return () => clearInterval(timer)
+  })
+
+  const elapsed = $derived.by(() => {
+    if (!running) return elapsedMs / 1000
+    if (startedAt) return Math.max(0, (now - startedAt) / 1000)
+    return progress?.elapsed ?? 0
+  })
+
+  // Short queries finish inside the sampling interval and never get a progress
+  // snapshot, so the readout falls back to the final statistics.
+  const readRows = $derived(running ? (progress?.read_rows ?? null) : (stats?.rows_read ?? null))
+  const readBytes = $derived(running ? (progress?.read_bytes ?? null) : (stats?.bytes_read ?? null))
+
+  // total_rows is ClickHouse's total_rows_approx: absent for sources it can't
+  // size up front (system tables, remote reads), so the bar goes indeterminate.
+  const rawPercent = $derived.by(() => {
+    if (!running || !progress || !progress.total_rows) return null
+    return Math.min(100, (progress.read_rows / progress.total_rows) * 100)
+  })
+
+  // ClickHouse revises total_rows_approx upward as it discovers parts to read,
+  // so the raw ratio can drop back after climbing. Keep the highest value seen
+  // in this run: a progress bar that walks backwards reads as a glitch.
+  let peakPercent = $state<number | null>(null)
+  let peakRun = $state<number | null>(null)
+  $effect(() => {
+    if (startedAt !== peakRun) {
+      peakRun = startedAt
+      peakPercent = null
+    }
+    if (rawPercent !== null && (peakPercent === null || rawPercent > peakPercent)) {
+      peakPercent = rawPercent
+    }
+  })
+  const percent = $derived(running ? peakPercent : null)
+
+  // Rates use ClickHouse's own elapsed while the query runs so they don't drift
+  // with client lag, and the measured duration once it is done. Tiny reads get
+  // no rate: dividing a handful of rows by a few milliseconds is noise.
+  const RATE_MIN_ROWS = 1_000
+  const rateWindow = $derived(running ? (progress?.elapsed ?? 0) : elapsed)
+  const showRate = $derived(readRows !== null && readRows >= RATE_MIN_ROWS && rateWindow > 0)
+  const rowsPerSec = $derived(showRate && readRows !== null ? readRows / rateWindow : null)
+  const bytesPerSec = $derived(showRate && readBytes !== null ? readBytes / rateWindow : null)
+
+  const detail = $derived.by(() => {
+    if (running && !progress) return 'Waiting for the first progress report from ClickHouse'
+
+    const lines: string[] = []
+    if (running && progress) {
+      lines.push(
+        progress.total_rows
+          ? `Read ${progress.read_rows.toLocaleString()} of ~${progress.total_rows.toLocaleString()} rows`
+          : `Read ${progress.read_rows.toLocaleString()} rows (total unknown for this source)`,
+      )
+      lines.push(`${formatBytes(progress.read_bytes)} read`)
+      if (progress.memory_usage > 0) lines.push(`${formatBytes(progress.memory_usage)} memory in use`)
+      lines.push(`Server elapsed: ${progress.elapsed.toFixed(3)}s`)
+      return lines.join('\n')
+    }
+
+    if (readRows !== null) lines.push(`Read ${readRows.toLocaleString()} rows`)
+    if (readBytes !== null) lines.push(`${formatBytes(readBytes)} read`)
+    lines.push(`Took ${elapsed.toFixed(3)}s`)
+    return lines.join('\n')
+  })
+</script>
+
+<div
+  class="relative overflow-hidden border-b border-gray-200 dark:border-gray-800 bg-gray-100/70 dark:bg-gray-900/60 shrink-0"
+  role="progressbar"
+  aria-label={running ? 'Query progress' : 'Query statistics'}
+  aria-valuemin={0}
+  aria-valuemax={100}
+  aria-valuenow={running ? (percent !== null ? Math.round(percent) : undefined) : 100}
+  title={detail}
+>
+  <!-- Fill: a measured bar when the row estimate is known, a sweep only when a
+       sample arrived without one. Nothing is drawn before the first sample, so
+       the bar fills once and grows instead of restarting a moment in. A
+       finished query gets no fill — the numbers are the result. -->
+  {#if running && percent !== null}
+    <div
+      class="absolute inset-y-0 left-0 bg-ch-blue/15 dark:bg-ch-blue/20 transition-[width] duration-300 ease-linear"
+      style="width: {percent}%"
+    ></div>
+  {:else if running && progress}
+    <div class="absolute inset-y-0 left-0 w-1/4 bg-ch-blue/15 dark:bg-ch-blue/20 animate-query-sweep"></div>
+  {/if}
+
+  <div class="relative flex items-center justify-between gap-2 px-2 py-1 text-[11px] text-gray-600 dark:text-gray-300">
+    <span class="flex items-center gap-1.5 shrink-0 tabular-nums">
+      <span
+        class="size-1.5 rounded-full {running ? 'bg-ch-blue animate-pulse' : 'bg-gray-400 dark:bg-gray-600'}"
+        aria-hidden="true"
+      ></span>
+      {elapsed.toFixed(2)}s
+    </span>
+
+    {#if readRows !== null}
+      <span class="flex items-center gap-1.5 min-w-0 justify-end tabular-nums">
+        {#if percent !== null}
+          <span class="shrink-0 font-medium text-ch-blue">{percent.toFixed(1)}%</span>
+        {/if}
+        <span class="truncate text-gray-500 dark:text-gray-400">
+          read {formatCompactNumber(readRows)} {readRows === 1 ? 'row' : 'rows'}{readBytes !== null ? ` · ${formatBytes(readBytes)}` : ''}
+        </span>
+        {#if rowsPerSec !== null && bytesPerSec !== null}
+          <span class="hidden lg:inline shrink-0 text-gray-400 dark:text-gray-500">
+            {formatCompactNumber(rowsPerSec)} rows/s · {formatBytes(bytesPerSec)}/s
+          </span>
+        {/if}
+      </span>
+    {:else}
+      <span class="truncate text-gray-400 dark:text-gray-500">{running ? 'Running…' : 'No read statistics reported'}</span>
+    {/if}
+  </div>
+</div>

--- a/ui/src/lib/components/editor/ResultFooter.svelte
+++ b/ui/src/lib/components/editor/ResultFooter.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { ColumnMeta, QueryStats } from '../../types/query'
-  import { formatNumber, formatElapsed, formatBytes } from '../../utils/format'
+  import { formatNumber, formatElapsed } from '../../utils/format'
   import {
     generateCSV,
     generateTSV,
@@ -159,14 +159,8 @@
       <span>{formatNumber(streamRows)} streamed</span>
       <span>{formatNumber(streamChunks)} chunks</span>
     {/if}
-    {#if stats}
-      {#if stats.rows_read}
-        <span>{formatNumber(stats.rows_read)} read</span>
-      {/if}
-      {#if stats.bytes_read}
-        <span>{formatBytes(stats.bytes_read)}</span>
-      {/if}
-    {/if}
+    <!-- Rows and bytes read live in the progress readout above the results, so
+         they are not repeated here. -->
   </div>
 
   <!-- Result filters toggle -->

--- a/ui/src/lib/components/editor/ResultPanel.svelte
+++ b/ui/src/lib/components/editor/ResultPanel.svelte
@@ -1,15 +1,17 @@
 <script lang="ts">
-  import type { ColumnMeta, QueryPlanNode, QueryStats, QueryEstimateResult } from '../../types/query'
+  import type { ColumnMeta, QueryPlanNode, QueryStats, QueryEstimateResult, QueryProgress } from '../../types/query'
   import type { ColumnFilter, ResultSort } from '../../utils/result-filters'
   import { OPERATOR_LABELS, isUnaryOperator } from '../../utils/result-filters'
   import VirtualTable from '../table/VirtualTable.svelte'
   import Spinner from '../common/Spinner.svelte'
   import ResultFooter from './ResultFooter.svelte'
   import StatsPanel from './StatsPanel.svelte'
+  import QueryProgressBar from './QueryProgressBar.svelte'
   import SchemaPanel from './SchemaPanel.svelte'
   import InsightsPanel from './InsightsPanel.svelte'
   import { computeColumnStats } from '../../utils/stats'
   import { parseCHError } from '../../utils/ch-error'
+  import { formatNumber } from '../../utils/format'
   import { SquareTerminal, AlertTriangle, X, Filter, Lightbulb, Crosshair } from 'lucide-svelte'
 
   type Tab = 'data' | 'stats' | 'schema' | 'insights'
@@ -26,6 +28,8 @@
     streamChunks?: number
     streamStartedAt?: number | null
     streamLastChunkAt?: number | null
+    /** Live progress of the running query; null before the first snapshot. */
+    progress?: QueryProgress | null
     planNodes?: QueryPlanNode[]
     planLines?: string[]
     planSource?: string
@@ -70,6 +74,7 @@
     streamChunks = 0,
     streamStartedAt = null,
     streamLastChunkAt = null,
+    progress = null,
     planNodes = [],
     planLines = [],
     planSource = '',
@@ -119,6 +124,13 @@
 </script>
 
 <div class="flex flex-col flex-1 min-h-0">
+  <!-- Query progress and statistics (rows read, throughput, percent done) stay
+       above every state: live while the query runs, then as the final numbers
+       for the run — a query too short to report progress still shows them. -->
+  {#if running || stats}
+    <QueryProgressBar {progress} startedAt={streamStartedAt} {running} {stats} {elapsedMs} />
+  {/if}
+
   <!-- Active filters stay visible in every state (including errors from a
        server-side re-query) so a failing filter can always be removed. -->
   {#if filters.length > 0 || partialView}
@@ -156,6 +168,9 @@
     <div class="flex flex-col items-center justify-center flex-1 gap-2 text-gray-500">
       <Spinner size="sm" />
       <span class="text-sm">Executing query...</span>
+      {#if streamRows > 0}
+        <span class="text-xs text-gray-400 dark:text-gray-600 tabular-nums">{formatNumber(streamRows)} rows received</span>
+      {/if}
     </div>
   {:else if error && parsedError}
     <div class="flex-1 p-4 overflow-auto">

--- a/ui/src/lib/components/layout/content/QueryContent.svelte
+++ b/ui/src/lib/components/layout/content/QueryContent.svelte
@@ -16,7 +16,7 @@
   import { filterRows, sortRows, cycleSort, isWrappableQuery, buildWrappedQuery } from '../../../utils/result-filters'
   import { getResultFiltersEnabled } from '../../../stores/result-filters.svelte'
   import { formatSQL, explainQuery, fetchQueryPlan, runSampleQuery, fetchQueryProfile, estimateQuery } from '../../../api/query'
-  import type { QueryPlanNode, QueryEstimateResult } from '../../../types/query'
+  import type { QueryPlanNode, QueryEstimateResult, QueryProgress } from '../../../types/query'
   import type { SavedQuery } from '../../../types/api'
   import { executeStreamQuery } from '../../../api/stream'
   import { apiPost, apiPut } from '../../../api/client'
@@ -53,6 +53,8 @@
   let streamChunks = $state(0)
   let streamStartedAt = $state<number | null>(null)
   let streamLastChunkAt = $state<number | null>(null)
+  // Live progress of the running query (rows read, throughput, percent done).
+  let streamProgress = $state<QueryProgress | null>(null)
 
   // Query plan state
   let planNodes = $state<QueryPlanNode[]>([])
@@ -210,6 +212,7 @@
     streamChunks = 0
     streamStartedAt = Date.now()
     streamLastChunkAt = null
+    streamProgress = null
     profile = null
     profileAvailable = false
     profileReason = null
@@ -270,6 +273,9 @@
         },
         abortController.signal,
         params,
+        (progress) => {
+          streamProgress = progress
+        },
       )
     } catch (e: any) {
       // AbortError is expected on cancel
@@ -805,6 +811,7 @@ WHERE user_id = {'{user_id:UInt64}'}
       {streamChunks}
       {streamStartedAt}
       {streamLastChunkAt}
+      progress={streamProgress}
       planNodes={planNodes}
       planLines={planLines}
       planSource={planSource}

--- a/ui/src/lib/types/query.ts
+++ b/ui/src/lib/types/query.ts
@@ -19,6 +19,18 @@ export interface QueryStats {
   bytes_read: number
 }
 
+/**
+ * Live progress of a running query, sampled from system.processes.
+ * `total_rows` is ClickHouse's total_rows_approx and is 0 when unknown.
+ */
+export interface QueryProgress {
+  read_rows: number
+  read_bytes: number
+  total_rows: number
+  memory_usage: number
+  elapsed: number
+}
+
 /** Explorer data response (server-side paginated) */
 export interface ExplorerDataResponse {
   success: boolean
@@ -89,5 +101,6 @@ export interface QueryEstimateResult {
 export type StreamMessage =
   | { type: 'meta'; meta: ColumnMeta[] }
   | { type: 'chunk'; data: unknown[][]; seq: number }
+  | { type: 'progress'; progress: QueryProgress }
   | { type: 'done'; statistics?: QueryStats; total_rows: number }
   | { type: 'error'; error: string }

--- a/ui/src/lib/utils/format.test.ts
+++ b/ui/src/lib/utils/format.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { formatCompactNumber } from './format'
+
+describe('formatCompactNumber', () => {
+  it('leaves small counts alone', () => {
+    expect(formatCompactNumber(0)).toBe('0')
+    expect(formatCompactNumber(1)).toBe('1')
+    expect(formatCompactNumber(999)).toBe('999')
+  })
+
+  it('scales large counts with a short suffix', () => {
+    expect(formatCompactNumber(1_500)).toBe('1.50K')
+    expect(formatCompactNumber(15_990_000)).toBe('15.99M')
+    expect(formatCompactNumber(3_020_000_000)).toBe('3.02B')
+    expect(formatCompactNumber(1_250_000_000_000)).toBe('1.25T')
+  })
+
+  it('handles fractional throughput values', () => {
+    expect(formatCompactNumber(2.5)).toBe('2.50')
+    expect(formatCompactNumber(3_020_500.5)).toBe('3.02M')
+  })
+})

--- a/ui/src/lib/utils/format.ts
+++ b/ui/src/lib/utils/format.ts
@@ -3,6 +3,25 @@ export function formatNumber(n: number): string {
   return n.toLocaleString()
 }
 
+/**
+ * Format a count compactly with a short scale suffix ("491.09B"), for progress
+ * readouts where the exact digits do not matter but the magnitude does.
+ */
+export function formatCompactNumber(n: number): string {
+  const abs = Math.abs(n)
+  if (abs < 1_000) return abs < 10 ? n.toFixed(abs % 1 === 0 ? 0 : 2) : n.toFixed(0)
+  const units: [number, string][] = [
+    [1e12, 'T'],
+    [1e9, 'B'],
+    [1e6, 'M'],
+    [1e3, 'K'],
+  ]
+  for (const [scale, suffix] of units) {
+    if (abs >= scale) return `${(n / scale).toFixed(2)}${suffix}`
+  }
+  return n.toFixed(0)
+}
+
 /** Format bytes to human readable (KB, MB, GB). Optional fixed decimal places. */
 export function formatBytes(bytes: number, decimals?: number): string {
   if (bytes === 0) return '0 B'


### PR DESCRIPTION
Closes #147.

ClickHouse already reports rows read, bytes read and total rows to read while a query is still executing — CH-UI just never showed it. Long queries looked frozen, so the honest workaround was opening ClickHouse's own `/play` next to CH-UI to see how far along a scan was. This PR brings those numbers into the editor.

---

## What it looks like

**While a query runs** — elapsed time, percent complete, rows and bytes read, read throughput. The bar fills with the completed fraction.

![Live progress while a query runs](https://raw.githubusercontent.com/markvh033/ch-ui/pr-assets/pr-147/01-running.png)

In context, above the result panel:

![Progress readout in the editor](https://raw.githubusercontent.com/markvh033/ch-ui/pr-assets/pr-147/05-context.png)

**When the query finishes** the readout stays, showing what the query actually read — so a sub-second query that never reports progress still tells you the story (0.71s, 130M rows, 2.0 GB scanned for a 12-row result):

![Statistics kept after the query finishes](https://raw.githubusercontent.com/markvh033/ch-ui/pr-assets/pr-147/02-finished.png)

**When ClickHouse cannot estimate the total** (unbounded sources such as `system.numbers`, remote reads) there is no honest percentage, so the bar sweeps instead of lying and the counters keep updating:

![Indeterminate progress](https://raw.githubusercontent.com/markvh033/ch-ui/pr-assets/pr-147/03-indeterminate.png)

**Light theme:**

![Light theme](https://raw.githubusercontent.com/markvh033/ch-ui/pr-assets/pr-147/04-running-light.png)

---

## How progress is obtained

Three options exist, and the two obvious ones do not work here:

| Option | Why not |
|---|---|
| `send_progress_in_http_headers=1` | ClickHouse emits progress as repeated header updates on an open response. Go's `net/http` does not surface headers until the response completes, so the client sees them only after the query is over. |
| `JSONCompactEachRowWithProgress` etc. | Needs ClickHouse 24.9+. The project's own `docker-compose.yml` pins 24.8, so this would silently drop progress for supported servers. |
| **Sampling `system.processes`** | Works on every supported version, needs no format change, and cannot corrupt the result stream. ✅ |

So the agent now tags each streamed query with a `query_id` and samples `system.processes` every 300 ms:

```sql
SELECT read_rows, read_bytes, total_rows_approx, memory_usage, elapsed
FROM system.processes WHERE query_id = '…'
```

Each snapshot travels over the **existing** tunnel and NDJSON query stream as a new `progress` message, so nothing about the transport or the result path changes:

```
agent ──progress──▶ tunnel gateway ──progress──▶ /api/query/stream (NDJSON) ──▶ editor
```

Properties worth calling out:

- **Best-effort.** Without `SELECT` on `system.processes` the readout falls back to the final statistics and queries run exactly as before — no new hard dependency, no new error surface. The first refused sample ends sampling for that query, so a user without the grant pays one extra request per query rather than three a second; a dropped connection or timeout is still treated as transient and retried, and a query that has simply finished keeps being sampled.
- **No log noise.** Samples run with `log_queries=0`, so they never appear in `system.query_log`, query history or Query Insights.
- **Injection-safe.** The `query_id` is validated against `[A-Za-z0-9_-]{1,64}` before it is embedded, and refused rather than escaped otherwise.
- **Backpressure-safe.** Progress snapshots are disposable: if the HTTP handler has not picked the previous one up, it is replaced, so a slow reader can never stall the agent's socket (unlike result chunks, which must not be dropped).
- **Not just `SELECT`.** `INSERT … SELECT` and `OPTIMIZE TABLE … FINAL` report progress too. Mutations (`ALTER TABLE … UPDATE`) are accepted and run in the background, so their readout covers only the statement — documented as such.

## Final statistics for streaming queries

`JSONCompactEachRow` carries no statistics block, which is why streamed queries only ever reported elapsed time. The final rows/bytes now come from two sources that are reconciled:

- `X-ClickHouse-Summary` response header — **exact** for queries that produce their output at the end (aggregations), partial for queries that stream rows, because the header is written when response headers are flushed.
- The last progress sample — **closer** for queries that stream rows.

Both are snapshots of counters that only grow, so the larger value is the later one. Verified: `SELECT sum(number) FROM numbers_mt(500000000000)` now reports exactly `500,000,000,000 read · 3.6 TB`.

## Progress that does not walk backwards

Two details, both visible in the screenshots above:

1. Nothing is drawn until the first sample arrives, so the bar fills **once** instead of showing a sweep animation and then restarting as a fill a moment later.
2. `total_rows_approx` is an estimate ClickHouse revises *upward* as it discovers parts to read, so a naive ratio can climb and then drop back mid-query. The displayed percentage keeps the highest value seen in the run.

Measured over a 5.5 s query (22 samples): percentage 5 → 91 monotonic, fill width monotonic, no sweep frames after the fill appears.

## Cancelling now actually cancels

An abandoned stream used to be left running to completion on ClickHouse — and with a `query_id` now assigned, it would also have left the sampler polling it. So:

- the gateway tells the agent when a stream is abandoned (client disconnect, `Cancel`, closed tab);
- the agent aborts its request **and** issues `KILL QUERY` for that `query_id`.

Closing the connection alone is not enough: a query that produces no output until it finishes never writes to the socket, so it never notices the client is gone. Before this change, aborting `SELECT count() FROM system.numbers` left it running indefinitely; it now disappears from `system.processes` within a second. A user can always kill their own queries, so no extra grant is required.

---

## Testing

Local stack: ClickHouse **24.8** (Docker) + `make dev` (Vite + Go server), embedded agent, 130M-row MergeTree table plus `numbers_mt` sources.

**Behaviour, driven through `/api/query/stream`:**

| Case | Result |
|---|---|
| Aggregation with known total (`sum(number) FROM numbers_mt(…)`) | progress samples with percentage, exact final statistics |
| Large row stream (2M rows) | progress interleaved with result chunks; row-limit truncation respected |
| Long bounded scan over `system.numbers` (28 s) | 94 samples, exact final statistics |
| Unbounded source (no `total_rows_approx`) | progress without percentage (indeterminate bar) |
| Instant query (`SELECT 1`) | no progress messages; readout falls back to final statistics |
| Unknown table / SQL error | error path unchanged |
| `CREATE TABLE` | unchanged, no progress |
| `INSERT … SELECT` (20M rows) | 31 samples, exact final statistics |
| `OPTIMIZE TABLE … FINAL` | 15 samples |
| `ALTER TABLE … UPDATE` | statement returns immediately, mutation runs in background (documented) |
| Explicit `FORMAT` clause | unchanged |
| User **without** `SELECT` on `system.processes` | no progress, query and final statistics unaffected, nothing logged, exactly one refused sample per query (checked via `system.errors`) |
| Client abort via `curl --max-time` and via editor `Cancel` | query killed on ClickHouse within ~1 s, no lingering processes |

**UI:** checked in light and dark themes at 1512, 1280, 1024, 834 and 390 px wide. The throughput pair hides below `lg`, the row/byte counters truncate rather than overflow, the sweep respects `prefers-reduced-motion`, and the readout carries `role="progressbar"` with `aria-valuenow`.

**Automated:**

- `gofmt` clean, `go vet ./...` clean, `go test ./... -race` green.
- New `connector/progress_test.go` — query-id safety (including injection attempts), quoted-`UInt64` parsing, summary-header parsing, sampling (running / not running / permission denied), refusal-vs-transient classification, the guarantee that a refused sample stops sampling after exactly one attempt without failing the query, progress delivery through `ExecuteStreaming`, and the guarantee that no `query_id` is attached and no sampling happens when no progress callback is supplied.
- `bun run check` (0 errors), `bun run test` (72 pass, includes new `formatCompactNumber` tests), `bun run build`.

## Notes for the reviewer

- The sampling interval is one constant (`progressPollInterval`, 300 ms) if you would prefer it looser.
- Rows/bytes read were removed from the result footer, since the readout above the results now owns those numbers; elapsed, row count and chunk counters stay in the footer.
- Two **pre-existing** bugs surfaced while testing this, both left untouched here — happy to send either as its own PR:
  - lightweight `DELETE FROM …` fails in the editor, because `DELETE` is missing from `writeQueryPattern`, so the column-metadata rewrite appends `LIMIT 0` to it;
  - a trailing `SETTINGS x = y` clause breaks the same rewrite (`LIMIT 0` lands after `SETTINGS` → syntax error).
- Documentation added under "ClickHouse grants used by the editor" in `docs/connecting-to-clickhouse.md`, plus a CHANGELOG entry and a README feature bullet.
