### PR TITLE
ci: pin govulncheck to v1.7.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Vulnerability scan (govulncheck)
         run: |
-          go install golang.org/x/vuln/cmd/govulncheck@latest
+          go install golang.org/x/vuln/cmd/govulncheck@v1.7.0
           govulncheck ./...
 
   frontend:


### PR DESCRIPTION
The backend CI job on main started failing on 2026-09-09 at the govulncheck step:

```
golang.org/x/vuln@v1.8.0 requires go >= 1.26.0 (running go 1.25.14; GOTOOLCHAIN=local)
```

golang.org/x/vuln v1.8.0 was released on 2026-09-08 and requires Go 1.26, so `go install ...@latest` no longer works with the Go version pinned in go.mod. This pins the tool to v1.7.0, the last release built for Go 1.25.

Follow-up: when go.mod moves to Go 1.26, bump this pin to v1.8.0 in the same change. Dependabot does not track `go install` lines in workflows.