### PR TITLE
feat(mcp): tool titles, annotations and server instructions

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -127,6 +127,11 @@ func unauthorized(w http.ResponseWriter, msg string) {
 	w.Write([]byte(`{"error":"` + msg + `"}`))
 }
 
+// serverInstructions is sent to the client at initialize/discover time. It is
+// the one place to tell the model how to work with this server well; keep it
+// short, clients prepend it to the system prompt.
+const serverInstructions = `CH-UI exposes one ClickHouse connection. Work schema-first: call list_databases, then list_tables, then describe_table before writing SQL; describe_table returns the sorting key, use it in WHERE clauses to avoid full scans. run_select is read-only, capped at 100 rows by default (max_rows up to 2000) and 60 seconds; aggregate or add LIMIT rather than paging through raw rows. Use explain_query before running an expensive query on a large table. ClickHouse SQL specifics: use toDate/toStartOfHour for time bucketing, uniq()/uniqExact() for distinct counts, and backticks for identifiers; there is no implicit type coercion between String and numbers. Tools with readOnlyHint=false only create drafts in CH-UI (saved queries, dashboards, models, pipelines); nothing they create runs against ClickHouse until a human reviews it in the UI.`
+
 // buildServer assembles the per-request MCP server bound to the authenticated
 // key. Free tools are always registered; Pro tools only with an active
 // license.
@@ -135,7 +140,7 @@ func buildServer(deps Deps, ak *authedKey) *mcp.Server {
 		Name:    "ch-ui",
 		Title:   "CH-UI — self-hosted ClickHouse console",
 		Version: version.Version,
-	}, nil)
+	}, &mcp.ServerOptions{Instructions: serverInstructions})
 
 	registerFreeTools(srv, deps, ak)
 	registerListTools(srv, deps, ak)

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -249,3 +249,68 @@ func TestErrResultShape(t *testing.T) {
 		t.Errorf("unexpected: %s", b)
 	}
 }
+
+// sseData returns the JSON payload of the first "data:" line in a streamable
+// HTTP response, which the SDK frames as server-sent events.
+func sseData(t *testing.T, body string) []byte {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "data:") {
+			return []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	t.Fatalf("no data line in response: %s", body)
+	return nil
+}
+
+// Every tool must carry a title and spec annotations: clients use
+// readOnlyHint/destructiveHint to decide whether to ask for confirmation, and
+// connector directories reject tools without them.
+func TestToolAnnotations(t *testing.T) {
+	// Write-scope key so the additive tools are listed too.
+	deps, _, key := writeDeps(t)
+	h := Handler(deps)
+
+	rec := mcpRequest(t, h, key, initializeBody)
+	if !strings.Contains(rec.Body.String(), "schema-first") {
+		t.Errorf("initialize should carry server instructions, got: %s", rec.Body.String())
+	}
+
+	rec = mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Title       string `json:"title"`
+				Annotations *struct {
+					Title           string `json:"title"`
+					ReadOnlyHint    bool   `json:"readOnlyHint"`
+					DestructiveHint *bool  `json:"destructiveHint"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(sseData(t, rec.Body.String()), &resp); err != nil {
+		t.Fatalf("decode tools/list: %v: %s", err, rec.Body.String())
+	}
+	if len(resp.Result.Tools) < 13 {
+		t.Fatalf("expected free + list + write tools, got %d", len(resp.Result.Tools))
+	}
+	writeTools := map[string]bool{"save_query": true, "create_dashboard": true, "create_model": true, "create_pipeline": true}
+	for _, tool := range resp.Result.Tools {
+		if tool.Title == "" || tool.Annotations == nil || tool.Annotations.Title == "" {
+			t.Errorf("%s: missing title or annotations", tool.Name)
+			continue
+		}
+		if writeTools[tool.Name] {
+			if tool.Annotations.ReadOnlyHint {
+				t.Errorf("%s: write tool must not be readOnlyHint", tool.Name)
+			}
+			if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+				t.Errorf("%s: additive tool must set destructiveHint=false", tool.Name)
+			}
+		} else if !tool.Annotations.ReadOnlyHint {
+			t.Errorf("%s: read tool must be readOnlyHint", tool.Name)
+		}
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -73,6 +73,32 @@ func sanitizeForHistory(q string) string {
 	return s
 }
 
+// readOnlyTool returns the metadata for a tool that never modifies anything:
+// title plus the spec's readOnlyHint/idempotentHint/openWorldHint. Clients use
+// these to skip confirmation prompts, and connector directories require them.
+func readOnlyTool(title string) (string, *mcp.ToolAnnotations) {
+	closed := false
+	return title, &mcp.ToolAnnotations{
+		Title:          title,
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
+		OpenWorldHint:  &closed,
+	}
+}
+
+// additiveTool returns the metadata for a tool that creates CH-UI entities but
+// never deletes or overwrites: readOnlyHint=false, destructiveHint=false.
+func additiveTool(title string) (string, *mcp.ToolAnnotations) {
+	f := false
+	return title, &mcp.ToolAnnotations{
+		Title:           title,
+		ReadOnlyHint:    false,
+		DestructiveHint: &f,
+		IdempotentHint:  false,
+		OpenWorldHint:   &f,
+	}
+}
+
 // errResult renders a tool-level error (IsError, not a protocol error) so the
 // model can read it and correct course.
 func errResult(format string, args ...any) *mcp.CallToolResult {
@@ -199,8 +225,11 @@ type explainArgs struct {
 }
 
 func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("List databases")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_databases",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the databases visible to this connection (filtered by the key's database allowlist).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		rows, err := runCH(deps, ak,
@@ -220,8 +249,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"databases": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List tables")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_tables",
+		Title:       title,
+		Annotations: ann,
 		Description: "List tables in a database with engine, row count and size on disk.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args listTablesArgs) (*mcp.CallToolResult, any, error) {
 		if args.Database == "" {
@@ -239,8 +271,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"database": args.Database, "tables": rows}), nil, nil
 	})
 
+	title, ann = readOnlyTool("Describe table")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "describe_table",
+		Title:       title,
+		Annotations: ann,
 		Description: "Describe a table: columns, types, comments, and the CREATE statement's sorting/partition keys.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args describeTableArgs) (*mcp.CallToolResult, any, error) {
 		if args.Database == "" || args.Table == "" {
@@ -268,8 +303,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(out), nil, nil
 	})
 
+	title, ann = readOnlyTool("Run read-only SQL")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "run_select",
+		Title:       title,
+		Annotations: ann,
 		Description: "Run a read-only SQL statement (SELECT / WITH / SHOW / DESCRIBE / EXPLAIN) and return the rows as JSON. Row-capped and time-limited; write statements are rejected and the session runs with readonly enforced. Every call is recorded in CH-UI query history and the audit log.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args runSelectArgs) (*mcp.CallToolResult, any, error) {
 		sql := strings.TrimSpace(args.SQL)
@@ -326,8 +364,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil, nil
 	})
 
+	title, ann = readOnlyTool("Explain query plan")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "explain_query",
+		Title:       title,
+		Annotations: ann,
 		Description: "Show ClickHouse's execution plan for a SELECT (EXPLAIN indexes = 1), useful to understand index usage and full scans before running an expensive query.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args explainArgs) (*mcp.CallToolResult, any, error) {
 		sql := strings.TrimSpace(args.SQL)

--- a/internal/mcpserver/tools_pro.go
+++ b/internal/mcpserver/tools_pro.go
@@ -36,8 +36,11 @@ var insightSections = map[string]func(cluster string, rng queryinsights.Range, f
 }
 
 func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("Top query patterns")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "query_insights_top",
+		Title:       title,
+		Annotations: ann,
 		Description: "Top query patterns from system.query_log, grouped by normalized query: slowest (p95), most memory-hungry, or most frequent. Requires the ClickHouse user to have access to system.query_log.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args insightsArgs) (*mcp.CallToolResult, any, error) {
 		builder, ok := insightSections[args.Section]
@@ -56,8 +59,11 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"section": args.Section, "range": rng.Name, "patterns": rows}), nil, nil
 	})
 
+	title, ann = readOnlyTool("Cost summary")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "costs_summary",
+		Title:       title,
+		Annotations: ann,
 		Description: "Cost Center summary for this connection: compute spend from real CPU consumption, spend on failed queries, core-hours, and scan volume, priced with the connection's configured rates.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args costsArgs) (*mcp.CallToolResult, any, error) {
 		rng, ok := costs.RangeSpec(args.Range)

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -86,8 +86,11 @@ var pipelineSourceTypes = map[string]bool{
 }
 
 func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := additiveTool("Save query")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "save_query",
+		Title:       title,
+		Annotations: ann,
 		Description: "Save a SQL query in CH-UI's saved queries library (visible to every user of this instance).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args saveQueryArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -109,8 +112,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"id": id, "name": name, "note": "saved; find it under Saved Queries"}), nil, nil
 	})
 
+	title, ann = additiveTool("Create dashboard")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_dashboard",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI dashboard with SQL panels. Panels lay out automatically two per row unless x/y coordinates are given.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createDashboardArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -167,8 +173,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"id": dashID, "name": name, "panels": created}), nil, nil
 	})
 
+	title, ann = additiveTool("Create draft model")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_model",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI SQL model as a draft. Models materialize as a view or table when run from the UI; reference other models with $ref(model_name). Model names are unique per connection.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createModelArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -215,8 +224,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}), nil, nil
 	})
 
+	title, ann = additiveTool("Create draft pipeline")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_pipeline",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI data pipeline as a draft: one source (kafka, webhook, database, or s3) wired to a ClickHouse sink table. Source settings can be completed in the UI; the pipeline never starts from here.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createPipelineArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -271,8 +283,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 // can see what already exists before creating (model names are unique per
 // connection). Available to every key.
 func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("List saved queries")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_saved_queries",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the saved queries in this CH-UI instance (name, description, creator).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		queries, err := deps.DB.GetSavedQueries()
@@ -286,8 +301,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"saved_queries": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List dashboards")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_dashboards",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the dashboards in this CH-UI instance.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		dashboards, err := deps.DB.GetDashboards()
@@ -301,8 +319,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"dashboards": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List models")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_models",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the SQL models on this connection (name, status, materialization).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		modelRows, err := deps.DB.GetModelsByConnection(ak.key.ConnectionID)
@@ -319,8 +340,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"models": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List pipelines")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_pipelines",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the data pipelines in this CH-UI instance (name, status).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		pipelines, err := deps.DB.GetPipelines()


### PR DESCRIPTION
First of the MCP catch-up PRs. No dependency changes.

- Every tool carries a `title` and spec annotations (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`). Read tools are read-only and idempotent; the four write-scope tools are `readOnlyHint=false`, `destructiveHint=false` because they only create drafts in CH-UI's store.
- The server sends `instructions` at initialize/discover time: schema-first workflow, use the sorting key, aggregate instead of paging, a few ClickHouse SQL specifics. Clients prepend this to the system prompt.
- New test asserts that every listed tool has a title and correct annotations, and that instructions are returned.

Why: clients use these hints to decide whether to ask for confirmation, and the Claude connectors directory and ChatGPT plugin review reject tools without them.