### PR TITLE
fix(mcp): hardening + pagination, csv format, exact row cap

### DIFF
--- a/internal/mcpserver/hardening_test.go
+++ b/internal/mcpserver/hardening_test.go
@@ -1,0 +1,110 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caioricciuti/ch-ui/internal/database"
+)
+
+func TestKeyLimiter(t *testing.T) {
+	l := &keyLimiter{windows: make(map[string]*rateEntry)}
+	for i := 0; i < rateLimit; i++ {
+		if !l.allow("k1") {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+	if l.allow("k1") {
+		t.Error("request past the limit should be denied")
+	}
+	if !l.allow("k2") {
+		t.Error("another key has its own budget")
+	}
+	// Expire the window: the key is allowed again.
+	l.windows["k1"].start = time.Now().Add(-2 * rateWindow)
+	if !l.allow("k1") {
+		t.Error("new window should be allowed")
+	}
+}
+
+func TestRateLimitedRequestGets429(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	keys, _ := deps.DB.ListMCPKeys()
+	limiter.mu.Lock()
+	limiter.windows[keys[0].ID] = &rateEntry{start: time.Now(), count: rateLimit}
+	limiter.mu.Unlock()
+	t.Cleanup(func() {
+		limiter.mu.Lock()
+		delete(limiter.windows, keys[0].ID)
+		limiter.mu.Unlock()
+	})
+
+	rec := mcpRequest(t, h, key, initializeBody)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("429 should carry Retry-After")
+	}
+}
+
+func TestListSavedQueriesScopedToConnection(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	keys, _ := deps.DB.ListMCPKeys()
+	mine := keys[0].ConnectionID
+	otherConn, err := deps.DB.CreateConnection(database.CreateConnectionParams{
+		Name: "other", TunnelToken: "cht_11111111111111111111111111111111", Type: database.ConnectionTypeTunnel,
+	})
+	if err != nil {
+		t.Fatalf("create other connection: %v", err)
+	}
+	for name, conn := range map[string]string{"mine": mine, "theirs": otherConn, "global": ""} {
+		if _, err := deps.DB.CreateSavedQuery(database.CreateSavedQueryParams{Name: name, Query: "SELECT 1", ConnectionID: conn}); err != nil {
+			t.Fatalf("create saved query %s: %v", name, err)
+		}
+	}
+
+	rec := mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_saved_queries","arguments":{}}}`)
+	body := string(sseData(t, rec.Body.String()))
+	// the tool payload is JSON inside a text content block, so quotes are escaped
+	if !strings.Contains(body, `\"name\":\"mine\"`) || !strings.Contains(body, `\"name\":\"global\"`) {
+		t.Errorf("expected own and global queries, got: %s", body)
+	}
+	if strings.Contains(body, `\"name\":\"theirs\"`) {
+		t.Errorf("saved query of another connection leaked: %s", body)
+	}
+}
+
+func TestEveryToolCallIsAudited(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"list_dashboards","arguments":{}}}`)
+
+	// audit rows are written asynchronously
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		logs, err := deps.DB.GetAuditLogs(20)
+		if err != nil {
+			t.Fatalf("audit logs: %v", err)
+		}
+		for _, l := range logs {
+			if l.Action == "mcp.tool.call" && l.Details != nil && strings.Contains(*l.Details, "tool: list_dashboards") {
+				b, _ := json.Marshal(l)
+				t.Logf("audit row: %s", b)
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no mcp.tool.call audit row for list_dashboards")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -21,7 +21,10 @@ import (
 	"encoding/hex"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -113,11 +116,78 @@ func authMiddleware(deps Deps, next http.Handler) http.Handler {
 			return
 		}
 
-		go deps.DB.TouchMCPKey(k.ID)
+		if !limiter.allow(k.ID) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", strconv.Itoa(int(rateWindow.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limit exceeded for this MCP key"}`))
+			return
+		}
+		touchKey(deps, k.ID)
 
 		ctx := context.WithValue(r.Context(), ctxKey, &authedKey{key: k, chPassword: password})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// ---- per-key rate limit and last-used throttle ----
+
+const (
+	// rateLimit is the number of MCP HTTP requests one key may make per
+	// rateWindow. Each tool call is one request; an agent loop that trips this
+	// is misbehaving, not working.
+	rateLimit  = 120
+	rateWindow = time.Minute
+
+	// touchInterval bounds how often last_used_at is written per key; a
+	// SQLite write per request is wasted I/O.
+	touchInterval = time.Minute
+)
+
+// keyLimiter is a fixed-window counter per key. In-memory on purpose: the
+// budget is per process and resets on restart, which is fine for abuse
+// control (the ClickHouse settings are the real resource guard).
+type keyLimiter struct {
+	mu      sync.Mutex
+	windows map[string]*rateEntry
+}
+
+type rateEntry struct {
+	start time.Time
+	count int
+}
+
+var limiter = &keyLimiter{windows: make(map[string]*rateEntry)}
+
+func (l *keyLimiter) allow(keyID string) bool {
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.windows[keyID]
+	if !ok || now.Sub(e.start) >= rateWindow {
+		l.windows[keyID] = &rateEntry{start: now, count: 1}
+		if len(l.windows) > 4096 { // keys revoked long ago; drop stale windows
+			for id, w := range l.windows {
+				if now.Sub(w.start) >= rateWindow {
+					delete(l.windows, id)
+				}
+			}
+		}
+		return true
+	}
+	e.count++
+	return e.count <= rateLimit
+}
+
+var lastTouch sync.Map // key ID -> time.Time
+
+func touchKey(deps Deps, keyID string) {
+	now := time.Now()
+	if v, ok := lastTouch.Load(keyID); ok && now.Sub(v.(time.Time)) < touchInterval {
+		return
+	}
+	lastTouch.Store(keyID, now)
+	go deps.DB.TouchMCPKey(keyID)
 }
 
 func unauthorized(w http.ResponseWriter, msg string) {
@@ -132,6 +202,38 @@ func unauthorized(w http.ResponseWriter, msg string) {
 // short, clients prepend it to the system prompt.
 const serverInstructions = `CH-UI exposes one ClickHouse connection. Work schema-first: call list_databases, then list_tables, then describe_table before writing SQL; describe_table returns the sorting key, use it in WHERE clauses to avoid full scans. run_select is read-only, capped at 100 rows by default (max_rows up to 2000) and 60 seconds; aggregate or add LIMIT rather than paging through raw rows. Use explain_query before running an expensive query on a large table. ClickHouse SQL specifics: use toDate/toStartOfHour for time bucketing, uniq()/uniqExact() for distinct counts, and backticks for identifiers; there is no implicit type coercion between String and numbers. Tools with readOnlyHint=false only create drafts in CH-UI (saved queries, dashboards, models, pipelines); nothing they create runs against ClickHouse until a human reviews it in the UI.`
 
+// auditToolCalls writes one audit row per tools/call so every tool, not just
+// run_select, is attributable to a key. run_select keeps its own richer
+// mcp.query.execute row (with the SQL in query history) and is skipped here.
+func auditToolCalls(deps Deps, ak *authedKey) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			res, err := next(ctx, method, req)
+			if method != "tools/call" {
+				return res, err
+			}
+			name := ""
+			switch p := req.GetParams().(type) {
+			case *mcp.CallToolParamsRaw:
+				name = p.Name
+			case *mcp.CallToolParams:
+				name = p.Name
+			}
+			if name == "" || name == "run_select" {
+				return res, err
+			}
+			status := "ok"
+			if err != nil {
+				status = "error"
+			} else if r, ok := res.(*mcp.CallToolResult); ok && r.IsError {
+				status = "error"
+			}
+			audit(deps, ak, "mcp.tool.call", "mcp key: "+ak.key.Name+", tool: "+name+", status: "+status)
+			return res, err
+		}
+	}
+}
+
 // buildServer assembles the per-request MCP server bound to the authenticated
 // key. Free tools are always registered; Pro tools only with an active
 // license.
@@ -142,6 +244,7 @@ func buildServer(deps Deps, ak *authedKey) *mcp.Server {
 		Version: version.Version,
 	}, &mcp.ServerOptions{Instructions: serverInstructions})
 
+	srv.AddReceivingMiddleware(auditToolCalls(deps, ak))
 	registerFreeTools(srv, deps, ak)
 	registerListTools(srv, deps, ak)
 	if ak.key.Scopes == "read_write" {

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -118,7 +118,7 @@ func jsonResult(v any) *mcp.CallToolResult {
 
 // runCH executes sql through the tunnel gateway with the key's credentials and
 // the given extra settings, returning decoded rows.
-func runCH(deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) ([]map[string]any, error) {
+func runCH(ctx context.Context, deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) ([]map[string]any, error) {
 	if !deps.Gateway.IsTunnelOnline(ak.key.ConnectionID) {
 		return nil, fmt.Errorf("connection %q is offline: its agent/tunnel is not connected to CH-UI", ak.key.ConnectionID)
 	}
@@ -130,7 +130,7 @@ func runCH(deps Deps, ak *authedKey, sql string, extra map[string]string, timeou
 	for k, v := range extra {
 		settings[k] = v
 	}
-	result, err := deps.Gateway.ExecuteQueryWithSettings(ak.key.ConnectionID, sql, ak.key.CHUser, ak.chPassword, settings, timeout)
+	result, err := deps.Gateway.ExecuteQueryWithSettingsCtx(ctx, ak.key.ConnectionID, sql, ak.key.CHUser, ak.chPassword, settings, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Annotations: ann,
 		Description: "List the databases visible to this connection (filtered by the key's database allowlist).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
-		rows, err := runCH(deps, ak,
+		rows, err := runCH(ctx, deps, ak,
 			"SELECT name, engine FROM system.databases WHERE name NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema') ORDER BY name FORMAT JSON",
 			nil, metaTimeout)
 		if err != nil {
@@ -262,7 +262,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if !dbAllowed(ak.key, args.Database) {
 			return errResult("database %q is not in this key's allowlist", args.Database), nil, nil
 		}
-		rows, err := runCH(deps, ak,
+		rows, err := runCH(ctx, deps, ak,
 			"SELECT name, engine, total_rows, total_bytes, comment FROM system.tables WHERE database = {db:String} ORDER BY name FORMAT JSON",
 			map[string]string{"param_db": args.Database}, metaTimeout)
 		if err != nil {
@@ -284,7 +284,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if !dbAllowed(ak.key, args.Database) {
 			return errResult("database %q is not in this key's allowlist", args.Database), nil, nil
 		}
-		cols, err := runCH(deps, ak,
+		cols, err := runCH(ctx, deps, ak,
 			"SELECT name, type, default_kind, default_expression, comment, is_in_primary_key, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = {db:String} AND table = {tbl:String} ORDER BY position FORMAT JSON",
 			map[string]string{"param_db": args.Database, "param_tbl": args.Table}, metaTimeout)
 		if err != nil {
@@ -293,7 +293,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if len(cols) == 0 {
 			return errResult("table %s.%s not found", args.Database, args.Table), nil, nil
 		}
-		meta, err := runCH(deps, ak,
+		meta, err := runCH(ctx, deps, ak,
 			"SELECT engine, partition_key, sorting_key, primary_key, total_rows, total_bytes FROM system.tables WHERE database = {db:String} AND name = {tbl:String} FORMAT JSON",
 			map[string]string{"param_db": args.Database, "param_tbl": args.Table}, metaTimeout)
 		out := map[string]any{"database": args.Database, "table": args.Table, "columns": cols}
@@ -337,7 +337,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 
 		start := time.Now()
-		rows, err := runCH(deps, ak, sql, settings, queryTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, settings, queryTimeout)
 		elapsed := time.Since(start)
 		if err != nil {
 			recordQuery(deps, ak, sql, "error", err.Error(), elapsed, 0)
@@ -382,7 +382,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if trailingFormatRe.MatchString(sql) {
 			return errResult("omit the FORMAT clause"), nil, nil
 		}
-		rows, err := runCH(deps, ak, "EXPLAIN indexes = 1\n"+sql+"\nFORMAT JSON", nil, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, "EXPLAIN indexes = 1\n"+sql+"\nFORMAT JSON", nil, metaTimeout)
 		if err != nil {
 			return errResult("explain failed: %v", err), nil, nil
 		}

--- a/internal/mcpserver/tools_pro.go
+++ b/internal/mcpserver/tools_pro.go
@@ -52,7 +52,7 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 			rng = queryinsights.DefaultRange
 		}
 		sql := builder("", rng, queryinsights.Filters{})
-		rows, err := runCH(deps, ak, sql, map[string]string{"log_comment": queryinsights.LogComment}, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, map[string]string{"log_comment": queryinsights.LogComment}, metaTimeout)
 		if err != nil {
 			return errResult("query_insights_top failed (is system.query_log accessible to this key's ClickHouse user?): %v", err), nil, nil
 		}
@@ -72,7 +72,7 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		cfg, isDefault := loadCostsConfig(deps, ak.key.ConnectionID)
 		sql := costs.SummaryQuery("", rng, cfg)
-		rows, err := runCH(deps, ak, sql, map[string]string{"log_comment": costs.LogComment}, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, map[string]string{"log_comment": costs.LogComment}, metaTimeout)
 		if err != nil {
 			return errResult("costs_summary failed (is system.query_log accessible to this key's ClickHouse user?): %v", err), nil, nil
 		}

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -288,7 +288,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_saved_queries",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the saved queries in this CH-UI instance (name, description, creator).",
+		Description: "List the saved queries usable on this connection (name, description, creator): queries bound to this connection plus connection-independent ones.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		queries, err := deps.DB.GetSavedQueries()
 		if err != nil {
@@ -296,6 +296,9 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		out := make([]map[string]any, 0, len(queries))
 		for _, q := range queries {
+			if q.ConnectionID != nil && *q.ConnectionID != "" && *q.ConnectionID != ak.key.ConnectionID {
+				continue
+			}
 			out = append(out, map[string]any{"id": q.ID, "name": q.Name, "description": q.Description, "created_by": q.CreatedBy})
 		}
 		return jsonResult(map[string]any{"saved_queries": out}), nil, nil
@@ -306,7 +309,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_dashboards",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the dashboards in this CH-UI instance.",
+		Description: "List the dashboards in this CH-UI instance. Dashboards are not bound to one connection; their panels may query other connections.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		dashboards, err := deps.DB.GetDashboards()
 		if err != nil {
@@ -345,7 +348,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_pipelines",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the data pipelines in this CH-UI instance (name, status).",
+		Description: "List the data pipelines on this connection (name, status).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		pipelines, err := deps.DB.GetPipelines()
 		if err != nil {
@@ -353,6 +356,9 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		out := make([]map[string]any, 0, len(pipelines))
 		for _, p := range pipelines {
+			if p.ConnectionID != ak.key.ConnectionID {
+				continue
+			}
 			out = append(out, map[string]any{"id": p.ID, "name": p.Name, "status": p.Status, "created_by": p.CreatedBy})
 		}
 		return jsonResult(map[string]any{"pipelines": out}), nil, nil

--- a/internal/tunnel/api.go
+++ b/internal/tunnel/api.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -45,6 +46,13 @@ func (g *Gateway) ExecuteQuery(connectionID, sql, user, password string, timeout
 // settings — including bind parameters (param_<name>) — to the agent, which
 // passes them to ClickHouse as URL params.
 func (g *Gateway) ExecuteQueryWithSettings(connectionID, sql, user, password string, settings map[string]string, timeout time.Duration) (*QueryResult, error) {
+	return g.ExecuteQueryWithSettingsCtx(context.Background(), connectionID, sql, user, password, settings, timeout)
+}
+
+// ExecuteQueryWithSettingsCtx is ExecuteQueryWithSettings bound to a context:
+// when ctx is cancelled before the agent answers, the query is cancelled on
+// the agent side too and ctx.Err() is returned.
+func (g *Gateway) ExecuteQueryWithSettingsCtx(ctx context.Context, connectionID, sql, user, password string, settings map[string]string, timeout time.Duration) (*QueryResult, error) {
 	val, ok := g.tunnels.Load(connectionID)
 	if !ok {
 		return nil, errors.New("tunnel not connected")
@@ -87,19 +95,26 @@ func (g *Gateway) ExecuteQueryWithSettings(connectionID, sql, user, password str
 		return &result, nil
 	case err := <-pending.ErrorCh:
 		return nil, err
+	case <-ctx.Done():
+		t.sendCancel(requestID)
+		return nil, ctx.Err()
 	case <-time.After(timeout):
-		// Send cancel to agent
-		cancel := GatewayMessage{
-			Type:    "cancel_query",
-			ID:      requestID,
-			QueryID: requestID,
-		}
-		cancelData, _ := json.Marshal(cancel)
-		t.mu.Lock()
-		t.WS.WriteMessage(websocket.TextMessage, cancelData)
-		t.mu.Unlock()
+		t.sendCancel(requestID)
 		return nil, errors.New("query timeout")
 	}
+}
+
+// sendCancel asks the agent to kill a query it is still running.
+func (t *ConnectedTunnel) sendCancel(requestID string) {
+	cancel := GatewayMessage{
+		Type:    "cancel_query",
+		ID:      requestID,
+		QueryID: requestID,
+	}
+	cancelData, _ := json.Marshal(cancel)
+	t.mu.Lock()
+	t.WS.WriteMessage(websocket.TextMessage, cancelData)
+	t.mu.Unlock()
 }
 
 // ExecuteQueryWithFormat sends a SQL query with a specific output format and returns the raw result.


### PR DESCRIPTION
Second MCP catch-up PR, now carrying #158's changes too (that PR was squashed into this branch when the stack was merged out of order). No dependency changes.

**Hardening**
- Cancellation: tool handlers pass their context into a new `Gateway.ExecuteQueryWithSettingsCtx`; a client disconnect or MCP cancel sends `cancel_query` to the agent.
- Rate limit: 120 requests per minute per key on `/mcp`, 429 with `Retry-After`. In-memory, no library.
- Audit every tool call as `mcp.tool.call`; `run_select` keeps its richer `mcp.query.execute` row.
- `last_used_at` written at most once a minute per key.
- `list_saved_queries` and `list_pipelines` scoped to the key's connection.

**Pagination and output**
- `list_tables`: `like`, `page_size` (default 50, max 500), opaque `cursor`, keyset on name, `next_cursor`.
- The four CH-UI list tools take `page_size` and `cursor` too.
- 200 KB cap enforced for every tool.
- `run_select`: `format: csv` (RFC 4180, header, ClickHouse column order), column list with types, `rows_read`/`bytes_read`, rows trimmed to `max_rows` exactly.

Tests for the limiter, 429 path, scoping, audit row, cursors, CSV, two-page listing. Full `go test ./...` green.