### PR TITLE
feat(mcp): hardening, pagination, csv output, per-client docs

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -1,25 +1,96 @@
 # MCP server
 
 CH-UI embeds a [Model Context Protocol](https://modelcontextprotocol.io) server,
-so AI clients (Claude Code, claude.ai custom connectors, Cursor, and any other
-MCP client) can browse schemas and run read-only queries against your
-self-hosted ClickHouse — through CH-UI, with CH-UI's auth, guardrails, and
+so AI clients (Claude Code, Cursor, VS Code, Zed, and any other MCP client that
+can send a bearer header) can browse schemas and run read-only queries against
+your self-hosted ClickHouse — through CH-UI, with CH-UI's auth, guardrails, and
 audit trail. No ClickHouse credentials on laptops, no extra process: it is the
 same `ch-ui` binary, serving streamable HTTP at `/mcp`.
+
+The server speaks the current MCP revision (2026-07-28, stateless) and the
+earlier handshake-based revisions, so old and new clients both work.
 
 ## Connect a client
 
 Create a key in **Admin → MCP Server** (admin only). The key is shown once.
-Then:
+Keep it out of shell history and config files where you can: every snippet
+below reads it from the `CH_UI_MCP_KEY` environment variable or a prompt.
+
+### Claude Code
 
 ```bash
-# Claude Code
 claude mcp add --transport http ch-ui https://your-ch-ui.example.com/mcp \
-  --header "Authorization: Bearer chm_..."
+  --header "Authorization: Bearer ${CH_UI_MCP_KEY}"
 ```
 
-For claude.ai custom connectors or Cursor, use the same URL and an
-`Authorization: Bearer chm_...` header.
+Or commit a project-level `.mcp.json` (the variable is expanded at load time,
+the key itself never lands in the file):
+
+```json
+{
+  "mcpServers": {
+    "ch-ui": {
+      "type": "http",
+      "url": "https://your-ch-ui.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${CH_UI_MCP_KEY}" }
+    }
+  }
+}
+```
+
+### Cursor
+
+`~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project):
+
+```json
+{
+  "mcpServers": {
+    "ch-ui": {
+      "url": "https://your-ch-ui.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${env:CH_UI_MCP_KEY}" }
+    }
+  }
+}
+```
+
+### VS Code / GitHub Copilot
+
+`.vscode/mcp.json`. The `inputs` block makes VS Code prompt for the key once
+and store it in its secret storage:
+
+```json
+{
+  "inputs": [
+    { "id": "ch-ui-key", "type": "promptString", "description": "CH-UI MCP key", "password": true }
+  ],
+  "servers": {
+    "ch-ui": {
+      "type": "http",
+      "url": "https://your-ch-ui.example.com/mcp",
+      "headers": { "Authorization": "Bearer ${input:ch-ui-key}" }
+    }
+  }
+}
+```
+
+### Zed, Devin Desktop (Windsurf), Gemini/Antigravity CLI
+
+All take a URL plus a `headers` map; use the same
+`Authorization: Bearer chm_...` header as above. Check the client's docs for
+the file location.
+
+### claude.ai and Claude Desktop
+
+Custom connectors in claude.ai require OAuth. The only header-based option is
+the org-scoped `static_headers` beta, which an organization admin has to
+enable; if you have it, add the same `Authorization` header there. Per-user
+OAuth login for CH-UI's MCP server is planned; until then, claude.ai users
+should use Claude Code.
+
+### ChatGPT
+
+ChatGPT plugins (formerly apps/connectors) accept OAuth only, so CH-UI's MCP
+server cannot be added to ChatGPT yet.
 
 ## What a key is
 
@@ -29,13 +100,19 @@ An MCP key binds three things:
   agent/tunnel, so firewalled instances work without exposing ports)
 - **a ClickHouse user** — the credentials queries run with. **This is the real
   permission boundary.** Create a dedicated, locked-down ClickHouse user for
-  MCP and grant it only what the AI should see.
+  MCP and grant it only what the AI should see. ClickHouse's own guidance for
+  agent users is a role with `readonly=1`, `max_execution_time`,
+  `max_memory_usage`, `max_rows_to_read` and `max_bytes_to_read` set.
 - **an optional database allowlist** — filters the schema-browsing tools
-  (`list_databases`, `list_tables`, `describe_table`). It is a visibility
-  filter, not a security boundary; use ClickHouse grants for enforcement.
+  (`list_databases`, `list_tables`, `describe_table`) and the target database
+  of `create_model` / `create_pipeline`. It does **not** parse the SQL passed
+  to `run_select` or `explain_query`; it is a visibility filter, not a
+  security boundary. Use ClickHouse grants for enforcement.
 
 Keys are bearer tokens (`chm_` prefix). Only a SHA-256 hash is stored; revoke
-them any time in Admin. There is no unauthenticated mode.
+them any time in Admin. There is no unauthenticated mode. Each key is limited
+to 120 requests per minute; over that the server answers `429` with
+`Retry-After`.
 
 Each key has a **scope**: `read` (default) or `read + write`. Write scope adds
 tools that create CH-UI entities (saved queries, dashboards, draft models and
@@ -44,20 +121,35 @@ and a read key never even sees the write tools.
 
 ## Tools
 
+Every tool carries a title and the MCP annotations clients use to decide
+whether to ask you before calling it: read tools are `readOnlyHint: true`,
+the write-scope tools are `readOnlyHint: false, destructiveHint: false`
+(they only ever add drafts).
+
 | Tool | What it does |
 |---|---|
 | `list_databases` | Databases visible to the connection (allowlist-filtered) |
-| `list_tables` | Tables in a database with engine, rows, size |
+| `list_tables` | Tables in a database with engine, rows, size. `like` filter, `page_size` (default 50, max 500), `cursor` |
 | `describe_table` | Columns, types, comments, sorting/partition keys |
-| `run_select` | Read-only SQL (SELECT / WITH / SHOW / DESCRIBE / EXPLAIN), row-capped |
+| `run_select` | Read-only SQL (SELECT / WITH / SHOW / DESCRIBE / EXPLAIN). `max_rows` (default 100, max 2000), `format` json or csv |
 | `explain_query` | `EXPLAIN indexes = 1` plan for a SELECT |
-| `list_saved_queries` / `list_dashboards` / `list_models` / `list_pipelines` | What already exists, before creating |
+| `list_saved_queries` / `list_dashboards` / `list_models` / `list_pipelines` | What already exists on this connection, paginated (`page_size`, `cursor`) |
 | `save_query` (write scope) | Save a query to the shared library |
 | `create_dashboard` (write scope) | Dashboard with SQL panels, auto-laid-out |
 | `create_model` (write scope) | Draft SQL model (view or table, `$ref()` supported) |
 | `create_pipeline` (write scope) | Draft pipeline: kafka/webhook/database/s3 source wired to a ClickHouse sink |
 | `query_insights_top` (Pro) | Top query patterns by p95 latency, memory, or frequency |
 | `costs_summary` (Pro) | Cost Center spend summary with your configured rates |
+
+Paginated tools return `next_cursor` when more items exist; pass it back as
+`cursor`. Cursors are opaque.
+
+`run_select` returns the rows, the column list with ClickHouse types, and the
+server's `rows_read` / `bytes_read`. With `format: csv` the rows come as an
+RFC 4180 block (header row, ClickHouse column order), which costs roughly half
+the tokens of JSON for wide results; the metadata follows as a second text
+block. Results are capped at `max_rows` exactly, and `truncated: true` tells
+the model to filter or aggregate.
 
 Write tools create **drafts** tagged `mcp:<key name>`: models and pipelines
 never run from MCP — you review and press play in the UI. Every create is
@@ -73,11 +165,16 @@ Layered, server-side, not prompt-side:
 3. **Statement gate**: anything that isn't SELECT / WITH / SHOW / DESCRIBE /
    EXPLAIN is rejected before reaching ClickHouse.
 4. **Caps**: `max_result_rows` (default 100, max 2000), 60s execution limit,
-   200KB response cap — results land in an LLM context, not a data pipeline.
-5. **Governance guardrails** (Pro): the same policies that gate the editor
-   evaluate every MCP query.
-6. **Observability**: every query lands in query history tagged `MCP` and in
-   the audit log as `mcp.query.execute`. You can always see what the AI did.
+   200KB response cap on every tool — results land in an LLM context, not a
+   data pipeline. A client that disconnects or cancels mid-query has its query
+   killed on the agent.
+5. **Rate limit**: 120 requests per minute per key.
+6. **Governance guardrails** (Pro): the same policies that gate the editor
+   evaluate every `run_select`.
+7. **Observability**: every `run_select` lands in query history tagged `MCP`
+   and in the audit log as `mcp.query.execute`; every other tool call is
+   audited as `mcp.tool.call` with the tool name and outcome. You can always
+   see what the AI did.
 
 ## Notes
 
@@ -87,3 +184,6 @@ Layered, server-side, not prompt-side:
 - The connection's agent must be online; tools return a clear "offline" error
   otherwise.
 - Pro tools appear only when a Pro license is active.
+- The server sends short instructions to the model at connect time (work
+  schema-first, use the sorting key, aggregate rather than page). Good prompts
+  on the client side still help: tell the model which database matters.

--- a/internal/mcpserver/hardening_test.go
+++ b/internal/mcpserver/hardening_test.go
@@ -1,0 +1,110 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/caioricciuti/ch-ui/internal/database"
+)
+
+func TestKeyLimiter(t *testing.T) {
+	l := &keyLimiter{windows: make(map[string]*rateEntry)}
+	for i := 0; i < rateLimit; i++ {
+		if !l.allow("k1") {
+			t.Fatalf("request %d should be allowed", i+1)
+		}
+	}
+	if l.allow("k1") {
+		t.Error("request past the limit should be denied")
+	}
+	if !l.allow("k2") {
+		t.Error("another key has its own budget")
+	}
+	// Expire the window: the key is allowed again.
+	l.windows["k1"].start = time.Now().Add(-2 * rateWindow)
+	if !l.allow("k1") {
+		t.Error("new window should be allowed")
+	}
+}
+
+func TestRateLimitedRequestGets429(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	keys, _ := deps.DB.ListMCPKeys()
+	limiter.mu.Lock()
+	limiter.windows[keys[0].ID] = &rateEntry{start: time.Now(), count: rateLimit}
+	limiter.mu.Unlock()
+	t.Cleanup(func() {
+		limiter.mu.Lock()
+		delete(limiter.windows, keys[0].ID)
+		limiter.mu.Unlock()
+	})
+
+	rec := mcpRequest(t, h, key, initializeBody)
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("want 429, got %d: %s", rec.Code, rec.Body.String())
+	}
+	if rec.Header().Get("Retry-After") == "" {
+		t.Error("429 should carry Retry-After")
+	}
+}
+
+func TestListSavedQueriesScopedToConnection(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	keys, _ := deps.DB.ListMCPKeys()
+	mine := keys[0].ConnectionID
+	otherConn, err := deps.DB.CreateConnection(database.CreateConnectionParams{
+		Name: "other", TunnelToken: "cht_11111111111111111111111111111111", Type: database.ConnectionTypeTunnel,
+	})
+	if err != nil {
+		t.Fatalf("create other connection: %v", err)
+	}
+	for name, conn := range map[string]string{"mine": mine, "theirs": otherConn, "global": ""} {
+		if _, err := deps.DB.CreateSavedQuery(database.CreateSavedQueryParams{Name: name, Query: "SELECT 1", ConnectionID: conn}); err != nil {
+			t.Fatalf("create saved query %s: %v", name, err)
+		}
+	}
+
+	rec := mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":5,"method":"tools/call","params":{"name":"list_saved_queries","arguments":{}}}`)
+	body := string(sseData(t, rec.Body.String()))
+	// the tool payload is JSON inside a text content block, so quotes are escaped
+	if !strings.Contains(body, `\"name\":\"mine\"`) || !strings.Contains(body, `\"name\":\"global\"`) {
+		t.Errorf("expected own and global queries, got: %s", body)
+	}
+	if strings.Contains(body, `\"name\":\"theirs\"`) {
+		t.Errorf("saved query of another connection leaked: %s", body)
+	}
+}
+
+func TestEveryToolCallIsAudited(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":6,"method":"tools/call","params":{"name":"list_dashboards","arguments":{}}}`)
+
+	// audit rows are written asynchronously
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		logs, err := deps.DB.GetAuditLogs(20)
+		if err != nil {
+			t.Fatalf("audit logs: %v", err)
+		}
+		for _, l := range logs {
+			if l.Action == "mcp.tool.call" && l.Details != nil && strings.Contains(*l.Details, "tool: list_dashboards") {
+				b, _ := json.Marshal(l)
+				t.Logf("audit row: %s", b)
+				return
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("no mcp.tool.call audit row for list_dashboards")
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+}

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -127,6 +127,11 @@ func unauthorized(w http.ResponseWriter, msg string) {
 	w.Write([]byte(`{"error":"` + msg + `"}`))
 }
 
+// serverInstructions is sent to the client at initialize/discover time. It is
+// the one place to tell the model how to work with this server well; keep it
+// short, clients prepend it to the system prompt.
+const serverInstructions = `CH-UI exposes one ClickHouse connection. Work schema-first: call list_databases, then list_tables, then describe_table before writing SQL; describe_table returns the sorting key, use it in WHERE clauses to avoid full scans. run_select is read-only, capped at 100 rows by default (max_rows up to 2000) and 60 seconds; aggregate or add LIMIT rather than paging through raw rows. Use explain_query before running an expensive query on a large table. ClickHouse SQL specifics: use toDate/toStartOfHour for time bucketing, uniq()/uniqExact() for distinct counts, and backticks for identifiers; there is no implicit type coercion between String and numbers. Tools with readOnlyHint=false only create drafts in CH-UI (saved queries, dashboards, models, pipelines); nothing they create runs against ClickHouse until a human reviews it in the UI.`
+
 // buildServer assembles the per-request MCP server bound to the authenticated
 // key. Free tools are always registered; Pro tools only with an active
 // license.
@@ -135,7 +140,7 @@ func buildServer(deps Deps, ak *authedKey) *mcp.Server {
 		Name:    "ch-ui",
 		Title:   "CH-UI — self-hosted ClickHouse console",
 		Version: version.Version,
-	}, nil)
+	}, &mcp.ServerOptions{Instructions: serverInstructions})
 
 	registerFreeTools(srv, deps, ak)
 	registerListTools(srv, deps, ak)

--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -21,7 +21,10 @@ import (
 	"encoding/hex"
 	"net/http"
 	"regexp"
+	"strconv"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
@@ -113,11 +116,78 @@ func authMiddleware(deps Deps, next http.Handler) http.Handler {
 			return
 		}
 
-		go deps.DB.TouchMCPKey(k.ID)
+		if !limiter.allow(k.ID) {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", strconv.Itoa(int(rateWindow.Seconds())))
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":"rate limit exceeded for this MCP key"}`))
+			return
+		}
+		touchKey(deps, k.ID)
 
 		ctx := context.WithValue(r.Context(), ctxKey, &authedKey{key: k, chPassword: password})
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
+}
+
+// ---- per-key rate limit and last-used throttle ----
+
+const (
+	// rateLimit is the number of MCP HTTP requests one key may make per
+	// rateWindow. Each tool call is one request; an agent loop that trips this
+	// is misbehaving, not working.
+	rateLimit  = 120
+	rateWindow = time.Minute
+
+	// touchInterval bounds how often last_used_at is written per key; a
+	// SQLite write per request is wasted I/O.
+	touchInterval = time.Minute
+)
+
+// keyLimiter is a fixed-window counter per key. In-memory on purpose: the
+// budget is per process and resets on restart, which is fine for abuse
+// control (the ClickHouse settings are the real resource guard).
+type keyLimiter struct {
+	mu      sync.Mutex
+	windows map[string]*rateEntry
+}
+
+type rateEntry struct {
+	start time.Time
+	count int
+}
+
+var limiter = &keyLimiter{windows: make(map[string]*rateEntry)}
+
+func (l *keyLimiter) allow(keyID string) bool {
+	now := time.Now()
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	e, ok := l.windows[keyID]
+	if !ok || now.Sub(e.start) >= rateWindow {
+		l.windows[keyID] = &rateEntry{start: now, count: 1}
+		if len(l.windows) > 4096 { // keys revoked long ago; drop stale windows
+			for id, w := range l.windows {
+				if now.Sub(w.start) >= rateWindow {
+					delete(l.windows, id)
+				}
+			}
+		}
+		return true
+	}
+	e.count++
+	return e.count <= rateLimit
+}
+
+var lastTouch sync.Map // key ID -> time.Time
+
+func touchKey(deps Deps, keyID string) {
+	now := time.Now()
+	if v, ok := lastTouch.Load(keyID); ok && now.Sub(v.(time.Time)) < touchInterval {
+		return
+	}
+	lastTouch.Store(keyID, now)
+	go deps.DB.TouchMCPKey(keyID)
 }
 
 func unauthorized(w http.ResponseWriter, msg string) {
@@ -132,6 +202,38 @@ func unauthorized(w http.ResponseWriter, msg string) {
 // short, clients prepend it to the system prompt.
 const serverInstructions = `CH-UI exposes one ClickHouse connection. Work schema-first: call list_databases, then list_tables, then describe_table before writing SQL; describe_table returns the sorting key, use it in WHERE clauses to avoid full scans. run_select is read-only, capped at 100 rows by default (max_rows up to 2000) and 60 seconds; aggregate or add LIMIT rather than paging through raw rows. Use explain_query before running an expensive query on a large table. ClickHouse SQL specifics: use toDate/toStartOfHour for time bucketing, uniq()/uniqExact() for distinct counts, and backticks for identifiers; there is no implicit type coercion between String and numbers. Tools with readOnlyHint=false only create drafts in CH-UI (saved queries, dashboards, models, pipelines); nothing they create runs against ClickHouse until a human reviews it in the UI.`
 
+// auditToolCalls writes one audit row per tools/call so every tool, not just
+// run_select, is attributable to a key. run_select keeps its own richer
+// mcp.query.execute row (with the SQL in query history) and is skipped here.
+func auditToolCalls(deps Deps, ak *authedKey) mcp.Middleware {
+	return func(next mcp.MethodHandler) mcp.MethodHandler {
+		return func(ctx context.Context, method string, req mcp.Request) (mcp.Result, error) {
+			res, err := next(ctx, method, req)
+			if method != "tools/call" {
+				return res, err
+			}
+			name := ""
+			switch p := req.GetParams().(type) {
+			case *mcp.CallToolParamsRaw:
+				name = p.Name
+			case *mcp.CallToolParams:
+				name = p.Name
+			}
+			if name == "" || name == "run_select" {
+				return res, err
+			}
+			status := "ok"
+			if err != nil {
+				status = "error"
+			} else if r, ok := res.(*mcp.CallToolResult); ok && r.IsError {
+				status = "error"
+			}
+			audit(deps, ak, "mcp.tool.call", "mcp key: "+ak.key.Name+", tool: "+name+", status: "+status)
+			return res, err
+		}
+	}
+}
+
 // buildServer assembles the per-request MCP server bound to the authenticated
 // key. Free tools are always registered; Pro tools only with an active
 // license.
@@ -142,6 +244,7 @@ func buildServer(deps Deps, ak *authedKey) *mcp.Server {
 		Version: version.Version,
 	}, &mcp.ServerOptions{Instructions: serverInstructions})
 
+	srv.AddReceivingMiddleware(auditToolCalls(deps, ak))
 	registerFreeTools(srv, deps, ak)
 	registerListTools(srv, deps, ak)
 	if ak.key.Scopes == "read_write" {

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -249,3 +249,68 @@ func TestErrResultShape(t *testing.T) {
 		t.Errorf("unexpected: %s", b)
 	}
 }
+
+// sseData returns the JSON payload of the first "data:" line in a streamable
+// HTTP response, which the SDK frames as server-sent events.
+func sseData(t *testing.T, body string) []byte {
+	t.Helper()
+	for _, line := range strings.Split(body, "\n") {
+		if strings.HasPrefix(line, "data:") {
+			return []byte(strings.TrimSpace(strings.TrimPrefix(line, "data:")))
+		}
+	}
+	t.Fatalf("no data line in response: %s", body)
+	return nil
+}
+
+// Every tool must carry a title and spec annotations: clients use
+// readOnlyHint/destructiveHint to decide whether to ask for confirmation, and
+// connector directories reject tools without them.
+func TestToolAnnotations(t *testing.T) {
+	// Write-scope key so the additive tools are listed too.
+	deps, _, key := writeDeps(t)
+	h := Handler(deps)
+
+	rec := mcpRequest(t, h, key, initializeBody)
+	if !strings.Contains(rec.Body.String(), "schema-first") {
+		t.Errorf("initialize should carry server instructions, got: %s", rec.Body.String())
+	}
+
+	rec = mcpRequest(t, h, key, `{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}`)
+	var resp struct {
+		Result struct {
+			Tools []struct {
+				Name        string `json:"name"`
+				Title       string `json:"title"`
+				Annotations *struct {
+					Title           string `json:"title"`
+					ReadOnlyHint    bool   `json:"readOnlyHint"`
+					DestructiveHint *bool  `json:"destructiveHint"`
+				} `json:"annotations"`
+			} `json:"tools"`
+		} `json:"result"`
+	}
+	if err := json.Unmarshal(sseData(t, rec.Body.String()), &resp); err != nil {
+		t.Fatalf("decode tools/list: %v: %s", err, rec.Body.String())
+	}
+	if len(resp.Result.Tools) < 13 {
+		t.Fatalf("expected free + list + write tools, got %d", len(resp.Result.Tools))
+	}
+	writeTools := map[string]bool{"save_query": true, "create_dashboard": true, "create_model": true, "create_pipeline": true}
+	for _, tool := range resp.Result.Tools {
+		if tool.Title == "" || tool.Annotations == nil || tool.Annotations.Title == "" {
+			t.Errorf("%s: missing title or annotations", tool.Name)
+			continue
+		}
+		if writeTools[tool.Name] {
+			if tool.Annotations.ReadOnlyHint {
+				t.Errorf("%s: write tool must not be readOnlyHint", tool.Name)
+			}
+			if tool.Annotations.DestructiveHint == nil || *tool.Annotations.DestructiveHint {
+				t.Errorf("%s: additive tool must set destructiveHint=false", tool.Name)
+			}
+		} else if !tool.Annotations.ReadOnlyHint {
+			t.Errorf("%s: read tool must be readOnlyHint", tool.Name)
+		}
+	}
+}

--- a/internal/mcpserver/pagination_test.go
+++ b/internal/mcpserver/pagination_test.go
@@ -1,0 +1,96 @@
+package mcpserver
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/caioricciuti/ch-ui/internal/database"
+)
+
+func TestPageOf(t *testing.T) {
+	items := make([]map[string]any, 0, 5)
+	for i := 0; i < 5; i++ {
+		items = append(items, map[string]any{"i": i})
+	}
+	page, next, err := pageOf(items, "", 2)
+	if err != nil || len(page) != 2 || next == "" {
+		t.Fatalf("first page: %v %d %q", err, len(page), next)
+	}
+	page, next, err = pageOf(items, next, 2)
+	if err != nil || len(page) != 2 || page[0]["i"] != 2 || next == "" {
+		t.Fatalf("second page: %v %v %q", err, page, next)
+	}
+	page, next, err = pageOf(items, next, 2)
+	if err != nil || len(page) != 1 || next != "" {
+		t.Fatalf("last page: %v %d %q", err, len(page), next)
+	}
+	if _, _, err := pageOf(items, "not-a-cursor!", 2); err == nil {
+		t.Error("garbage cursor should fail")
+	}
+	if _, _, err := pageOf(items, encodeCursor("name", "x"), 2); err == nil {
+		t.Error("keyset cursor on an offset list should fail")
+	}
+	if clampPageSize(0) != defaultPageSize || clampPageSize(10_000) != hardMaxPageSize || clampPageSize(7) != 7 {
+		t.Error("clampPageSize bounds")
+	}
+}
+
+func TestToCSV(t *testing.T) {
+	cols := []chColumn{{Name: "b", Type: "String"}, {Name: "a", Type: "Float64"}, {Name: "n", Type: "Nullable(Int8)"}}
+	rows := []map[string]any{
+		{"a": 1.5, "b": "x,y", "n": nil},
+		{"a": float64(2), "b": `say "hi"`, "n": float64(3)},
+	}
+	got := toCSV(cols, rows)
+	want := "b,a,n\n\"x,y\",1.5,\n\"say \"\"hi\"\"\",2,3\n"
+	if got != want {
+		t.Errorf("csv mismatch:\n got: %q\nwant: %q", got, want)
+	}
+}
+
+func TestListToolsPaginateOverHTTP(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+	keys, _ := deps.DB.ListMCPKeys()
+	for _, name := range []string{"q1", "q2", "q3"} {
+		if _, err := deps.DB.CreateSavedQuery(database.CreateSavedQueryParams{Name: name, Query: "SELECT 1", ConnectionID: keys[0].ConnectionID}); err != nil {
+			t.Fatalf("create %s: %v", name, err)
+		}
+	}
+	type page struct {
+		SavedQueries []map[string]any `json:"saved_queries"`
+		NextCursor   string           `json:"next_cursor"`
+	}
+	call := func(cursor string) page {
+		body := `{"jsonrpc":"2.0","id":7,"method":"tools/call","params":{"name":"list_saved_queries","arguments":{"page_size":2,"cursor":"` + cursor + `"}}}`
+		rec := mcpRequest(t, h, key, body)
+		var env struct {
+			Result struct {
+				IsError bool `json:"isError"`
+				Content []struct {
+					Text string `json:"text"`
+				} `json:"content"`
+			} `json:"result"`
+		}
+		if err := json.Unmarshal(sseData(t, rec.Body.String()), &env); err != nil || env.Result.IsError || len(env.Result.Content) == 0 {
+			t.Fatalf("bad tool response: %v %s", err, rec.Body.String())
+		}
+		var p page
+		if err := json.Unmarshal([]byte(env.Result.Content[0].Text), &p); err != nil {
+			t.Fatalf("decode page: %v", err)
+		}
+		return p
+	}
+	first := call("")
+	if len(first.SavedQueries) != 2 || first.NextCursor == "" {
+		t.Fatalf("first page: %d items, cursor %q", len(first.SavedQueries), first.NextCursor)
+	}
+	second := call(first.NextCursor)
+	if len(second.SavedQueries) != 1 || second.NextCursor != "" {
+		t.Fatalf("second page: %d items, cursor %q", len(second.SavedQueries), second.NextCursor)
+	}
+	if strings.EqualFold(first.SavedQueries[0]["name"].(string), second.SavedQueries[0]["name"].(string)) {
+		t.Error("pages overlap")
+	}
+}

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -1,7 +1,10 @@
 package mcpserver
 
 import (
+	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -20,6 +23,9 @@ const (
 
 	defaultMaxRows = 100
 	hardMaxRows    = 2000
+
+	defaultPageSize = 50
+	hardMaxPageSize = 500
 
 	// maxResultBytes caps the serialized rows returned to the client; MCP
 	// results land in an LLM context window, not a data pipeline.
@@ -113,12 +119,145 @@ func jsonResult(v any) *mcp.CallToolResult {
 	if err != nil {
 		return errResult("failed to serialize result: %v", err)
 	}
+	if len(b) > maxResultBytes {
+		return errResult("result too large (%d KB, cap %d KB): use a smaller page_size, select fewer columns, add filters, or aggregate", len(b)/1024, maxResultBytes/1024)
+	}
 	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}
+}
+
+// ---- pagination ----
+//
+// Every list tool returns at most page_size items and a next_cursor when more
+// exist. Cursors are opaque to the client: base64url of either "name:<last>"
+// (keyset, for system tables) or "off:<n>" (offset, for CH-UI's own lists).
+
+func encodeCursor(kind, v string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(kind + ":" + v))
+}
+
+func decodeCursor(c string) (kind, v string, err error) {
+	if c == "" {
+		return "", "", nil
+	}
+	b, err := base64.RawURLEncoding.DecodeString(c)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid cursor")
+	}
+	kind, v, ok := strings.Cut(string(b), ":")
+	if !ok {
+		return "", "", fmt.Errorf("invalid cursor")
+	}
+	return kind, v, nil
+}
+
+func clampPageSize(n int) int {
+	if n <= 0 {
+		return defaultPageSize
+	}
+	if n > hardMaxPageSize {
+		return hardMaxPageSize
+	}
+	return n
+}
+
+// pageOf slices an in-memory list by an offset cursor and returns the page
+// plus the next cursor ("" when this is the last page).
+func pageOf(items []map[string]any, cursor string, pageSize int) ([]map[string]any, string, error) {
+	kind, v, err := decodeCursor(cursor)
+	if err != nil {
+		return nil, "", err
+	}
+	offset := 0
+	if kind == "off" {
+		if offset, err = strconv.Atoi(v); err != nil || offset < 0 {
+			return nil, "", fmt.Errorf("invalid cursor")
+		}
+	} else if kind != "" {
+		return nil, "", fmt.Errorf("invalid cursor")
+	}
+	if offset >= len(items) {
+		return []map[string]any{}, "", nil
+	}
+	end := offset + pageSize
+	next := ""
+	if end < len(items) {
+		next = encodeCursor("off", strconv.Itoa(end))
+	} else {
+		end = len(items)
+	}
+	return items[offset:end], next, nil
+}
+
+// chColumn is one entry of ClickHouse's JSON "meta" array, which preserves
+// column order (rows decode into maps and lose it).
+type chColumn struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+// chStats is ClickHouse's JSON "statistics" block.
+type chStats struct {
+	Elapsed   float64 `json:"elapsed"`
+	RowsRead  int64   `json:"rows_read"`
+	BytesRead int64   `json:"bytes_read"`
+}
+
+// chResult is a decoded gateway result with column order and server stats.
+type chResult struct {
+	Rows    []map[string]any
+	Columns []chColumn
+	Stats   *chStats
+}
+
+// toCSV renders rows as RFC 4180 CSV with a header, in ClickHouse column
+// order. Roughly half the tokens of the JSON envelope for wide results.
+func toCSV(cols []chColumn, rows []map[string]any) string {
+	var buf bytes.Buffer
+	w := csv.NewWriter(&buf)
+	header := make([]string, len(cols))
+	for i, c := range cols {
+		header[i] = c.Name
+	}
+	w.Write(header)
+	rec := make([]string, len(cols))
+	for _, r := range rows {
+		for i, c := range cols {
+			rec[i] = cellString(r[c.Name])
+		}
+		w.Write(rec)
+	}
+	w.Flush()
+	return buf.String()
+}
+
+func cellString(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return x
+	case float64:
+		return strconv.FormatFloat(x, 'f', -1, 64)
+	case bool:
+		return strconv.FormatBool(x)
+	default:
+		b, _ := json.Marshal(x)
+		return string(b)
+	}
 }
 
 // runCH executes sql through the tunnel gateway with the key's credentials and
 // the given extra settings, returning decoded rows.
 func runCH(ctx context.Context, deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) ([]map[string]any, error) {
+	res, err := runCHFull(ctx, deps, ak, sql, extra, timeout)
+	if err != nil {
+		return nil, err
+	}
+	return res.Rows, nil
+}
+
+// runCHFull is runCH keeping ClickHouse's column metadata and statistics.
+func runCHFull(ctx context.Context, deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) (*chResult, error) {
 	if !deps.Gateway.IsTunnelOnline(ak.key.ConnectionID) {
 		return nil, fmt.Errorf("connection %q is offline: its agent/tunnel is not connected to CH-UI", ak.key.ConnectionID)
 	}
@@ -134,13 +273,22 @@ func runCH(ctx context.Context, deps Deps, ak *authedKey, sql string, extra map[
 	if err != nil {
 		return nil, err
 	}
-	var rows []map[string]any
+	out := &chResult{}
 	if len(result.Data) > 0 {
-		if err := json.Unmarshal(result.Data, &rows); err != nil {
+		if err := json.Unmarshal(result.Data, &out.Rows); err != nil {
 			return nil, fmt.Errorf("failed to decode result rows: %w", err)
 		}
 	}
-	return rows, nil
+	if len(result.Meta) > 0 {
+		json.Unmarshal(result.Meta, &out.Columns) // best effort; rows still usable
+	}
+	if len(result.Stats) > 0 {
+		var st chStats
+		if json.Unmarshal(result.Stats, &st) == nil {
+			out.Stats = &st
+		}
+	}
+	return out, nil
 }
 
 // allowedDBs returns the key's database allowlist as a set; nil means
@@ -208,6 +356,15 @@ func checkGuardrails(deps Deps, ak *authedKey, sql, endpoint string) *mcp.CallTo
 
 type listTablesArgs struct {
 	Database string `json:"database" jsonschema:"the database to list tables from"`
+	Like     string `json:"like,omitempty" jsonschema:"optional SQL LIKE pattern on the table name, e.g. %events%"`
+	PageSize int    `json:"page_size,omitempty" jsonschema:"tables per page (default 50, max 500)"`
+	Cursor   string `json:"cursor,omitempty" jsonschema:"opaque cursor from a previous next_cursor to fetch the next page"`
+}
+
+// pageArgs is the shared pagination input of CH-UI's own list tools.
+type pageArgs struct {
+	PageSize int    `json:"page_size,omitempty" jsonschema:"items per page (default 50, max 500)"`
+	Cursor   string `json:"cursor,omitempty" jsonschema:"opaque cursor from a previous next_cursor to fetch the next page"`
 }
 
 type describeTableArgs struct {
@@ -218,6 +375,7 @@ type describeTableArgs struct {
 type runSelectArgs struct {
 	SQL     string `json:"sql" jsonschema:"the read-only SQL statement to run (SELECT / WITH / SHOW / DESCRIBE / EXPLAIN)"`
 	MaxRows int    `json:"max_rows,omitempty" jsonschema:"maximum rows to return (default 100, max 2000)"`
+	Format  string `json:"format,omitempty" jsonschema:"result format: json (default, rows as objects) or csv (header + rows, about half the tokens for wide results)"`
 }
 
 type explainArgs struct {
@@ -262,13 +420,34 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if !dbAllowed(ak.key, args.Database) {
 			return errResult("database %q is not in this key's allowlist", args.Database), nil, nil
 		}
+		kind, after, err := decodeCursor(args.Cursor)
+		if err != nil || (kind != "" && kind != "name") {
+			return errResult("invalid cursor; pass the next_cursor value from the previous page"), nil, nil
+		}
+		pageSize := clampPageSize(args.PageSize)
+		like := strings.TrimSpace(args.Like)
+		if like == "" {
+			like = "%"
+		}
+		// Keyset pagination on name (unique per database); fetch one extra row
+		// to know whether a next page exists.
 		rows, err := runCH(ctx, deps, ak,
-			"SELECT name, engine, total_rows, total_bytes, comment FROM system.tables WHERE database = {db:String} ORDER BY name FORMAT JSON",
-			map[string]string{"param_db": args.Database}, metaTimeout)
+			"SELECT name, engine, total_rows, total_bytes, comment FROM system.tables WHERE database = {db:String} AND name > {after:String} AND name LIKE {like:String} ORDER BY name LIMIT {lim:UInt32} FORMAT JSON",
+			map[string]string{"param_db": args.Database, "param_after": after, "param_like": like, "param_lim": strconv.Itoa(pageSize + 1)}, metaTimeout)
 		if err != nil {
 			return errResult("list_tables failed: %v", err), nil, nil
 		}
-		return jsonResult(map[string]any{"database": args.Database, "tables": rows}), nil, nil
+		out := map[string]any{"database": args.Database}
+		if len(rows) > pageSize {
+			rows = rows[:pageSize]
+			last, _ := rows[len(rows)-1]["name"].(string)
+			out["next_cursor"] = encodeCursor("name", last)
+		}
+		if rows == nil {
+			rows = []map[string]any{}
+		}
+		out["tables"] = rows
+		return jsonResult(out), nil, nil
 	})
 
 	title, ann = readOnlyTool("Describe table")
@@ -336,32 +515,61 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 			"max_execution_time": strconv.Itoa(int(queryTimeout.Seconds())),
 		}
 
+		format := strings.ToLower(strings.TrimSpace(args.Format))
+		if format == "" {
+			format = "json"
+		}
+		if format != "json" && format != "csv" {
+			return errResult("format must be json or csv"), nil, nil
+		}
+
 		start := time.Now()
-		rows, err := runCH(ctx, deps, ak, sql, settings, queryTimeout)
+		res, err := runCHFull(ctx, deps, ak, sql, settings, queryTimeout)
 		elapsed := time.Since(start)
 		if err != nil {
 			recordQuery(deps, ak, sql, "error", err.Error(), elapsed, 0)
 			return errResult("query failed: %v", err), nil, nil
 		}
+		rows := res.Rows
+		// result_overflow_mode=break stops at block granularity, so ClickHouse
+		// may hand back more than max_result_rows; trim so the cap is exact.
+		truncated := len(rows) >= maxRows
+		if len(rows) > maxRows {
+			rows = rows[:maxRows]
+		}
 		recordQuery(deps, ak, sql, "success", "", elapsed, int64(len(rows)))
 
-		payload := map[string]any{
-			"rows":       rows,
+		meta := map[string]any{
 			"row_count":  len(rows),
 			"elapsed_ms": elapsed.Milliseconds(),
 		}
-		if len(rows) >= maxRows {
-			payload["truncated"] = true
-			payload["note"] = fmt.Sprintf("result capped at %d rows; add filters or LIMIT for more precision", maxRows)
+		if len(res.Columns) > 0 {
+			meta["columns"] = res.Columns
 		}
-		b, jerr := json.Marshal(payload)
-		if jerr != nil {
-			return errResult("failed to serialize result: %v", jerr), nil, nil
+		if res.Stats != nil {
+			meta["stats"] = map[string]any{"rows_read": res.Stats.RowsRead, "bytes_read": res.Stats.BytesRead}
 		}
-		if len(b) > maxResultBytes {
-			return errResult("result too large (%d KB, cap %d KB): select fewer columns, add filters, or aggregate", len(b)/1024, maxResultBytes/1024), nil, nil
+		if truncated {
+			meta["truncated"] = true
+			meta["note"] = fmt.Sprintf("result capped at %d rows; add filters, aggregate, or raise max_rows (up to %d)", maxRows, hardMaxRows)
 		}
-		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil, nil
+
+		if format == "csv" {
+			body := toCSV(res.Columns, rows)
+			if len(body) > maxResultBytes {
+				return errResult("result too large (%d KB, cap %d KB): select fewer columns, add filters, or aggregate", len(body)/1024, maxResultBytes/1024), nil, nil
+			}
+			mb, _ := json.Marshal(meta)
+			return &mcp.CallToolResult{Content: []mcp.Content{
+				&mcp.TextContent{Text: body},
+				&mcp.TextContent{Text: string(mb)},
+			}}, nil, nil
+		}
+		if rows == nil {
+			rows = []map[string]any{}
+		}
+		meta["rows"] = rows
+		return jsonResult(meta), nil, nil
 	})
 
 	title, ann = readOnlyTool("Explain query plan")

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -73,6 +73,32 @@ func sanitizeForHistory(q string) string {
 	return s
 }
 
+// readOnlyTool returns the metadata for a tool that never modifies anything:
+// title plus the spec's readOnlyHint/idempotentHint/openWorldHint. Clients use
+// these to skip confirmation prompts, and connector directories require them.
+func readOnlyTool(title string) (string, *mcp.ToolAnnotations) {
+	closed := false
+	return title, &mcp.ToolAnnotations{
+		Title:          title,
+		ReadOnlyHint:   true,
+		IdempotentHint: true,
+		OpenWorldHint:  &closed,
+	}
+}
+
+// additiveTool returns the metadata for a tool that creates CH-UI entities but
+// never deletes or overwrites: readOnlyHint=false, destructiveHint=false.
+func additiveTool(title string) (string, *mcp.ToolAnnotations) {
+	f := false
+	return title, &mcp.ToolAnnotations{
+		Title:           title,
+		ReadOnlyHint:    false,
+		DestructiveHint: &f,
+		IdempotentHint:  false,
+		OpenWorldHint:   &f,
+	}
+}
+
 // errResult renders a tool-level error (IsError, not a protocol error) so the
 // model can read it and correct course.
 func errResult(format string, args ...any) *mcp.CallToolResult {
@@ -199,8 +225,11 @@ type explainArgs struct {
 }
 
 func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("List databases")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_databases",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the databases visible to this connection (filtered by the key's database allowlist).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		rows, err := runCH(deps, ak,
@@ -220,8 +249,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"databases": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List tables")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_tables",
+		Title:       title,
+		Annotations: ann,
 		Description: "List tables in a database with engine, row count and size on disk.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args listTablesArgs) (*mcp.CallToolResult, any, error) {
 		if args.Database == "" {
@@ -239,8 +271,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"database": args.Database, "tables": rows}), nil, nil
 	})
 
+	title, ann = readOnlyTool("Describe table")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "describe_table",
+		Title:       title,
+		Annotations: ann,
 		Description: "Describe a table: columns, types, comments, and the CREATE statement's sorting/partition keys.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args describeTableArgs) (*mcp.CallToolResult, any, error) {
 		if args.Database == "" || args.Table == "" {
@@ -268,8 +303,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(out), nil, nil
 	})
 
+	title, ann = readOnlyTool("Run read-only SQL")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "run_select",
+		Title:       title,
+		Annotations: ann,
 		Description: "Run a read-only SQL statement (SELECT / WITH / SHOW / DESCRIBE / EXPLAIN) and return the rows as JSON. Row-capped and time-limited; write statements are rejected and the session runs with readonly enforced. Every call is recorded in CH-UI query history and the audit log.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args runSelectArgs) (*mcp.CallToolResult, any, error) {
 		sql := strings.TrimSpace(args.SQL)
@@ -326,8 +364,11 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: string(b)}}}, nil, nil
 	})
 
+	title, ann = readOnlyTool("Explain query plan")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "explain_query",
+		Title:       title,
+		Annotations: ann,
 		Description: "Show ClickHouse's execution plan for a SELECT (EXPLAIN indexes = 1), useful to understand index usage and full scans before running an expensive query.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args explainArgs) (*mcp.CallToolResult, any, error) {
 		sql := strings.TrimSpace(args.SQL)

--- a/internal/mcpserver/tools.go
+++ b/internal/mcpserver/tools.go
@@ -118,7 +118,7 @@ func jsonResult(v any) *mcp.CallToolResult {
 
 // runCH executes sql through the tunnel gateway with the key's credentials and
 // the given extra settings, returning decoded rows.
-func runCH(deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) ([]map[string]any, error) {
+func runCH(ctx context.Context, deps Deps, ak *authedKey, sql string, extra map[string]string, timeout time.Duration) ([]map[string]any, error) {
 	if !deps.Gateway.IsTunnelOnline(ak.key.ConnectionID) {
 		return nil, fmt.Errorf("connection %q is offline: its agent/tunnel is not connected to CH-UI", ak.key.ConnectionID)
 	}
@@ -130,7 +130,7 @@ func runCH(deps Deps, ak *authedKey, sql string, extra map[string]string, timeou
 	for k, v := range extra {
 		settings[k] = v
 	}
-	result, err := deps.Gateway.ExecuteQueryWithSettings(ak.key.ConnectionID, sql, ak.key.CHUser, ak.chPassword, settings, timeout)
+	result, err := deps.Gateway.ExecuteQueryWithSettingsCtx(ctx, ak.key.ConnectionID, sql, ak.key.CHUser, ak.chPassword, settings, timeout)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +232,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Annotations: ann,
 		Description: "List the databases visible to this connection (filtered by the key's database allowlist).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
-		rows, err := runCH(deps, ak,
+		rows, err := runCH(ctx, deps, ak,
 			"SELECT name, engine FROM system.databases WHERE name NOT IN ('system', 'INFORMATION_SCHEMA', 'information_schema') ORDER BY name FORMAT JSON",
 			nil, metaTimeout)
 		if err != nil {
@@ -262,7 +262,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if !dbAllowed(ak.key, args.Database) {
 			return errResult("database %q is not in this key's allowlist", args.Database), nil, nil
 		}
-		rows, err := runCH(deps, ak,
+		rows, err := runCH(ctx, deps, ak,
 			"SELECT name, engine, total_rows, total_bytes, comment FROM system.tables WHERE database = {db:String} ORDER BY name FORMAT JSON",
 			map[string]string{"param_db": args.Database}, metaTimeout)
 		if err != nil {
@@ -284,7 +284,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if !dbAllowed(ak.key, args.Database) {
 			return errResult("database %q is not in this key's allowlist", args.Database), nil, nil
 		}
-		cols, err := runCH(deps, ak,
+		cols, err := runCH(ctx, deps, ak,
 			"SELECT name, type, default_kind, default_expression, comment, is_in_primary_key, is_in_sorting_key, is_in_partition_key FROM system.columns WHERE database = {db:String} AND table = {tbl:String} ORDER BY position FORMAT JSON",
 			map[string]string{"param_db": args.Database, "param_tbl": args.Table}, metaTimeout)
 		if err != nil {
@@ -293,7 +293,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if len(cols) == 0 {
 			return errResult("table %s.%s not found", args.Database, args.Table), nil, nil
 		}
-		meta, err := runCH(deps, ak,
+		meta, err := runCH(ctx, deps, ak,
 			"SELECT engine, partition_key, sorting_key, primary_key, total_rows, total_bytes FROM system.tables WHERE database = {db:String} AND name = {tbl:String} FORMAT JSON",
 			map[string]string{"param_db": args.Database, "param_tbl": args.Table}, metaTimeout)
 		out := map[string]any{"database": args.Database, "table": args.Table, "columns": cols}
@@ -337,7 +337,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 
 		start := time.Now()
-		rows, err := runCH(deps, ak, sql, settings, queryTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, settings, queryTimeout)
 		elapsed := time.Since(start)
 		if err != nil {
 			recordQuery(deps, ak, sql, "error", err.Error(), elapsed, 0)
@@ -382,7 +382,7 @@ func registerFreeTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		if trailingFormatRe.MatchString(sql) {
 			return errResult("omit the FORMAT clause"), nil, nil
 		}
-		rows, err := runCH(deps, ak, "EXPLAIN indexes = 1\n"+sql+"\nFORMAT JSON", nil, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, "EXPLAIN indexes = 1\n"+sql+"\nFORMAT JSON", nil, metaTimeout)
 		if err != nil {
 			return errResult("explain failed: %v", err), nil, nil
 		}

--- a/internal/mcpserver/tools_pro.go
+++ b/internal/mcpserver/tools_pro.go
@@ -36,8 +36,11 @@ var insightSections = map[string]func(cluster string, rng queryinsights.Range, f
 }
 
 func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("Top query patterns")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "query_insights_top",
+		Title:       title,
+		Annotations: ann,
 		Description: "Top query patterns from system.query_log, grouped by normalized query: slowest (p95), most memory-hungry, or most frequent. Requires the ClickHouse user to have access to system.query_log.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args insightsArgs) (*mcp.CallToolResult, any, error) {
 		builder, ok := insightSections[args.Section]
@@ -56,8 +59,11 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"section": args.Section, "range": rng.Name, "patterns": rows}), nil, nil
 	})
 
+	title, ann = readOnlyTool("Cost summary")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "costs_summary",
+		Title:       title,
+		Annotations: ann,
 		Description: "Cost Center summary for this connection: compute spend from real CPU consumption, spend on failed queries, core-hours, and scan volume, priced with the connection's configured rates.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args costsArgs) (*mcp.CallToolResult, any, error) {
 		rng, ok := costs.RangeSpec(args.Range)

--- a/internal/mcpserver/tools_pro.go
+++ b/internal/mcpserver/tools_pro.go
@@ -52,7 +52,7 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 			rng = queryinsights.DefaultRange
 		}
 		sql := builder("", rng, queryinsights.Filters{})
-		rows, err := runCH(deps, ak, sql, map[string]string{"log_comment": queryinsights.LogComment}, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, map[string]string{"log_comment": queryinsights.LogComment}, metaTimeout)
 		if err != nil {
 			return errResult("query_insights_top failed (is system.query_log accessible to this key's ClickHouse user?): %v", err), nil, nil
 		}
@@ -72,7 +72,7 @@ func registerProTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		cfg, isDefault := loadCostsConfig(deps, ak.key.ConnectionID)
 		sql := costs.SummaryQuery("", rng, cfg)
-		rows, err := runCH(deps, ak, sql, map[string]string{"log_comment": costs.LogComment}, metaTimeout)
+		rows, err := runCH(ctx, deps, ak, sql, map[string]string{"log_comment": costs.LogComment}, metaTimeout)
 		if err != nil {
 			return errResult("costs_summary failed (is system.query_log accessible to this key's ClickHouse user?): %v", err), nil, nil
 		}

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -86,8 +86,11 @@ var pipelineSourceTypes = map[string]bool{
 }
 
 func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := additiveTool("Save query")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "save_query",
+		Title:       title,
+		Annotations: ann,
 		Description: "Save a SQL query in CH-UI's saved queries library (visible to every user of this instance).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args saveQueryArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -109,8 +112,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"id": id, "name": name, "note": "saved; find it under Saved Queries"}), nil, nil
 	})
 
+	title, ann = additiveTool("Create dashboard")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_dashboard",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI dashboard with SQL panels. Panels lay out automatically two per row unless x/y coordinates are given.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createDashboardArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -167,8 +173,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"id": dashID, "name": name, "panels": created}), nil, nil
 	})
 
+	title, ann = additiveTool("Create draft model")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_model",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI SQL model as a draft. Models materialize as a view or table when run from the UI; reference other models with $ref(model_name). Model names are unique per connection.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createModelArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -215,8 +224,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}), nil, nil
 	})
 
+	title, ann = additiveTool("Create draft pipeline")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "create_pipeline",
+		Title:       title,
+		Annotations: ann,
 		Description: "Create a CH-UI data pipeline as a draft: one source (kafka, webhook, database, or s3) wired to a ClickHouse sink table. Source settings can be completed in the UI; the pipeline never starts from here.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, args createPipelineArgs) (*mcp.CallToolResult, any, error) {
 		name := strings.TrimSpace(args.Name)
@@ -271,8 +283,11 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 // can see what already exists before creating (model names are unique per
 // connection). Available to every key.
 func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
+	title, ann := readOnlyTool("List saved queries")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_saved_queries",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the saved queries in this CH-UI instance (name, description, creator).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		queries, err := deps.DB.GetSavedQueries()
@@ -286,8 +301,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"saved_queries": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List dashboards")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_dashboards",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the dashboards in this CH-UI instance.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		dashboards, err := deps.DB.GetDashboards()
@@ -301,8 +319,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"dashboards": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List models")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_models",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the SQL models on this connection (name, status, materialization).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		modelRows, err := deps.DB.GetModelsByConnection(ak.key.ConnectionID)
@@ -319,8 +340,11 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		return jsonResult(map[string]any{"models": out}), nil, nil
 	})
 
+	title, ann = readOnlyTool("List pipelines")
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "list_pipelines",
+		Title:       title,
+		Annotations: ann,
 		Description: "List the data pipelines in this CH-UI instance (name, status).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		pipelines, err := deps.DB.GetPipelines()

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -279,6 +279,20 @@ func registerWriteTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 	})
 }
 
+// pagedResult renders one page of an in-memory list under key, with
+// next_cursor when more items remain.
+func pagedResult(key string, items []map[string]any, args pageArgs) *mcp.CallToolResult {
+	page, next, err := pageOf(items, args.Cursor, clampPageSize(args.PageSize))
+	if err != nil {
+		return errResult("invalid cursor; pass the next_cursor value from the previous page")
+	}
+	out := map[string]any{key: page}
+	if next != "" {
+		out["next_cursor"] = next
+	}
+	return jsonResult(out)
+}
+
 // registerListTools exposes read-only listings of CH-UI entities so a client
 // can see what already exists before creating (model names are unique per
 // connection). Available to every key.
@@ -289,7 +303,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Title:       title,
 		Annotations: ann,
 		Description: "List the saved queries usable on this connection (name, description, creator): queries bound to this connection plus connection-independent ones.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args pageArgs) (*mcp.CallToolResult, any, error) {
 		queries, err := deps.DB.GetSavedQueries()
 		if err != nil {
 			return errResult("failed to list saved queries: %v", err), nil, nil
@@ -301,7 +315,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 			}
 			out = append(out, map[string]any{"id": q.ID, "name": q.Name, "description": q.Description, "created_by": q.CreatedBy})
 		}
-		return jsonResult(map[string]any{"saved_queries": out}), nil, nil
+		return pagedResult("saved_queries", out, args), nil, nil
 	})
 
 	title, ann = readOnlyTool("List dashboards")
@@ -310,7 +324,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Title:       title,
 		Annotations: ann,
 		Description: "List the dashboards in this CH-UI instance. Dashboards are not bound to one connection; their panels may query other connections.",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args pageArgs) (*mcp.CallToolResult, any, error) {
 		dashboards, err := deps.DB.GetDashboards()
 		if err != nil {
 			return errResult("failed to list dashboards: %v", err), nil, nil
@@ -319,7 +333,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		for _, d := range dashboards {
 			out = append(out, map[string]any{"id": d.ID, "name": d.Name, "description": d.Description, "created_by": d.CreatedBy})
 		}
-		return jsonResult(map[string]any{"dashboards": out}), nil, nil
+		return pagedResult("dashboards", out, args), nil, nil
 	})
 
 	title, ann = readOnlyTool("List models")
@@ -328,7 +342,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Title:       title,
 		Annotations: ann,
 		Description: "List the SQL models on this connection (name, status, materialization).",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args pageArgs) (*mcp.CallToolResult, any, error) {
 		modelRows, err := deps.DB.GetModelsByConnection(ak.key.ConnectionID)
 		if err != nil {
 			return errResult("failed to list models: %v", err), nil, nil
@@ -340,7 +354,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 				"materialization": m.Materialization, "target_database": m.TargetDatabase,
 			})
 		}
-		return jsonResult(map[string]any{"models": out}), nil, nil
+		return pagedResult("models", out, args), nil, nil
 	})
 
 	title, ann = readOnlyTool("List pipelines")
@@ -349,7 +363,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Title:       title,
 		Annotations: ann,
 		Description: "List the data pipelines on this connection (name, status).",
-	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
+	}, func(ctx context.Context, req *mcp.CallToolRequest, args pageArgs) (*mcp.CallToolResult, any, error) {
 		pipelines, err := deps.DB.GetPipelines()
 		if err != nil {
 			return errResult("failed to list pipelines: %v", err), nil, nil
@@ -361,6 +375,6 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 			}
 			out = append(out, map[string]any{"id": p.ID, "name": p.Name, "status": p.Status, "created_by": p.CreatedBy})
 		}
-		return jsonResult(map[string]any{"pipelines": out}), nil, nil
+		return pagedResult("pipelines", out, args), nil, nil
 	})
 }

--- a/internal/mcpserver/tools_write.go
+++ b/internal/mcpserver/tools_write.go
@@ -288,7 +288,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_saved_queries",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the saved queries in this CH-UI instance (name, description, creator).",
+		Description: "List the saved queries usable on this connection (name, description, creator): queries bound to this connection plus connection-independent ones.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		queries, err := deps.DB.GetSavedQueries()
 		if err != nil {
@@ -296,6 +296,9 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		out := make([]map[string]any, 0, len(queries))
 		for _, q := range queries {
+			if q.ConnectionID != nil && *q.ConnectionID != "" && *q.ConnectionID != ak.key.ConnectionID {
+				continue
+			}
 			out = append(out, map[string]any{"id": q.ID, "name": q.Name, "description": q.Description, "created_by": q.CreatedBy})
 		}
 		return jsonResult(map[string]any{"saved_queries": out}), nil, nil
@@ -306,7 +309,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_dashboards",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the dashboards in this CH-UI instance.",
+		Description: "List the dashboards in this CH-UI instance. Dashboards are not bound to one connection; their panels may query other connections.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		dashboards, err := deps.DB.GetDashboards()
 		if err != nil {
@@ -345,7 +348,7 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		Name:        "list_pipelines",
 		Title:       title,
 		Annotations: ann,
-		Description: "List the data pipelines in this CH-UI instance (name, status).",
+		Description: "List the data pipelines on this connection (name, status).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, _ struct{}) (*mcp.CallToolResult, any, error) {
 		pipelines, err := deps.DB.GetPipelines()
 		if err != nil {
@@ -353,6 +356,9 @@ func registerListTools(srv *mcp.Server, deps Deps, ak *authedKey) {
 		}
 		out := make([]map[string]any, 0, len(pipelines))
 		for _, p := range pipelines {
+			if p.ConnectionID != ak.key.ConnectionID {
+				continue
+			}
 			out = append(out, map[string]any{"id": p.ID, "name": p.Name, "status": p.Status, "created_by": p.CreatedBy})
 		}
 		return jsonResult(map[string]any{"pipelines": out}), nil, nil

--- a/internal/tunnel/api.go
+++ b/internal/tunnel/api.go
@@ -1,6 +1,7 @@
 package tunnel
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
@@ -45,6 +46,13 @@ func (g *Gateway) ExecuteQuery(connectionID, sql, user, password string, timeout
 // settings — including bind parameters (param_<name>) — to the agent, which
 // passes them to ClickHouse as URL params.
 func (g *Gateway) ExecuteQueryWithSettings(connectionID, sql, user, password string, settings map[string]string, timeout time.Duration) (*QueryResult, error) {
+	return g.ExecuteQueryWithSettingsCtx(context.Background(), connectionID, sql, user, password, settings, timeout)
+}
+
+// ExecuteQueryWithSettingsCtx is ExecuteQueryWithSettings bound to a context:
+// when ctx is cancelled before the agent answers, the query is cancelled on
+// the agent side too and ctx.Err() is returned.
+func (g *Gateway) ExecuteQueryWithSettingsCtx(ctx context.Context, connectionID, sql, user, password string, settings map[string]string, timeout time.Duration) (*QueryResult, error) {
 	val, ok := g.tunnels.Load(connectionID)
 	if !ok {
 		return nil, errors.New("tunnel not connected")
@@ -87,19 +95,26 @@ func (g *Gateway) ExecuteQueryWithSettings(connectionID, sql, user, password str
 		return &result, nil
 	case err := <-pending.ErrorCh:
 		return nil, err
+	case <-ctx.Done():
+		t.sendCancel(requestID)
+		return nil, ctx.Err()
 	case <-time.After(timeout):
-		// Send cancel to agent
-		cancel := GatewayMessage{
-			Type:    "cancel_query",
-			ID:      requestID,
-			QueryID: requestID,
-		}
-		cancelData, _ := json.Marshal(cancel)
-		t.mu.Lock()
-		t.WS.WriteMessage(websocket.TextMessage, cancelData)
-		t.mu.Unlock()
+		t.sendCancel(requestID)
 		return nil, errors.New("query timeout")
 	}
+}
+
+// sendCancel asks the agent to kill a query it is still running.
+func (t *ConnectedTunnel) sendCancel(requestID string) {
+	cancel := GatewayMessage{
+		Type:    "cancel_query",
+		ID:      requestID,
+		QueryID: requestID,
+	}
+	cancelData, _ := json.Marshal(cancel)
+	t.mu.Lock()
+	t.WS.WriteMessage(websocket.TextMessage, cancelData)
+	t.mu.Unlock()
 }
 
 // ExecuteQueryWithFormat sends a SQL query with a specific output format and returns the raw result.


### PR DESCRIPTION
Replaces #157, #158 and #159, which were closed when the stack was merged out of order (#158 was squashed into this branch, the other two lost their base branches). One PR now carries all three. No dependency changes.

**Hardening**
- Cancellation: tool handlers pass their context into a new `Gateway.ExecuteQueryWithSettingsCtx`; a client disconnect or MCP cancel sends `cancel_query` to the agent instead of letting ClickHouse run to the 60 s timeout.
- Rate limit: 120 requests per minute per key on `/mcp`, 429 with `Retry-After`. In-memory fixed window, no library.
- Audit every tool call as `mcp.tool.call` (tool name, ok/error); `run_select` keeps its richer `mcp.query.execute` row and query history.
- `last_used_at` written at most once a minute per key.
- `list_saved_queries` and `list_pipelines` scoped to the key's connection. Dashboards are not connection-bound and stay instance-wide.

**Pagination and output**
- `list_tables`: `like`, `page_size` (default 50, max 500), opaque `cursor`, keyset on name, `next_cursor`.
- The four CH-UI list tools take `page_size` and `cursor` too.
- The 200 KB cap is enforced for every tool.
- `run_select`: `format: csv` (RFC 4180, header, ClickHouse column order, about half the tokens of JSON), column list with types, `rows_read`/`bytes_read`, rows trimmed to `max_rows` exactly.

**Docs** (docs/mcp.md)
- Setup for Claude Code, Cursor, VS Code (key from environment or secret input), notes for Zed, Devin, Gemini/Antigravity.
- Honest claude.ai (OAuth required; org-only static_headers beta) and ChatGPT (OAuth only, not supported yet) status.
- Pagination, csv, rate limit, annotations, allowlist scope, cancellation, audit coverage.

Tests: limiter, 429 path, scoping, audit row, cursors, CSV, two-page listing. Full `go test ./...` green.