### PR TITLE
fix(mcp): allow proxied requests on a loopback listener

### DIFF
--- a/internal/mcpserver/mcpserver.go
+++ b/internal/mcpserver/mcpserver.go
@@ -84,7 +84,18 @@ func Handler(deps Deps) http.Handler {
 			return nil
 		}
 		return buildServer(deps, ak)
-	}, &mcp.StreamableHTTPOptions{Stateless: true})
+	}, &mcp.StreamableHTTPOptions{
+		Stateless: true,
+		// The SDK's DNS-rebinding guard rejects any request that arrives on a
+		// loopback socket with a non-loopback Host header. That is exactly what
+		// a reverse proxy on the same host produces (upstream 127.0.0.1:3488,
+		// Host: ch-ui.example.com), so every proxied MCP client got a 403
+		// "invalid Host header". The guard exists for unauthenticated local
+		// servers a browser page could reach via rebinding; /mcp requires a
+		// bearer key or OAuth token on every request and browsers never attach
+		// those ambiently, so a rebinding page gets the same 401 as anyone.
+		DisableLocalhostProtection: true,
+	})
 
 	return authMiddleware(deps, streamable)
 }

--- a/internal/mcpserver/mcpserver_test.go
+++ b/internal/mcpserver/mcpserver_test.go
@@ -1,7 +1,9 @@
 package mcpserver
 
 import (
+	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
@@ -175,6 +177,27 @@ func TestAuthRejections(t *testing.T) {
 	}
 	if rec := mcpRequest(t, h, key, initializeBody); rec.Code != http.StatusUnauthorized {
 		t.Errorf("revoked key: want 401, got %d", rec.Code)
+	}
+}
+
+// A reverse proxy on the same host forwards to 127.0.0.1 with the public
+// hostname in Host. The MCP SDK's DNS-rebinding guard turns that into a 403
+// unless disabled; /mcp is bearer-authenticated so the guard must stay off.
+func TestProxiedRequestOnLoopbackIsNotRejected(t *testing.T) {
+	deps, key := testDeps(t)
+	h := Handler(deps)
+
+	req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(initializeBody))
+	req.Host = "ch-ui.example.com"
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer "+key)
+	ctx := context.WithValue(req.Context(), http.LocalAddrContextKey, &net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 3488})
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req.WithContext(ctx))
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("proxied initialize on loopback: want 200, got %d: %s", rec.Code, rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Problem

Any MCP client connecting through a reverse proxy on the same host as CH-UI gets:

```
HTTP 403 Forbidden: invalid Host header "ch-ui.example.com"
```

The 403 comes from the MCP Go SDK's DNS-rebinding guard in `StreamableHTTPHandler.ServeHTTP`, which rejects a request that arrives on a loopback socket with a non-loopback Host header. That is exactly what the shipped `ch-ui.conf` produces: upstream `127.0.0.1:3488`, `proxy_set_header Host $host`. The guard runs after `authMiddleware` has already accepted the key, so clients report it as an auth failure. Docker deployments are unaffected because the container binds to a non-loopback address.

Present since the MCP endpoint landed in 2.9.x (go-sdk v1.7.0 from day one). Not caused by a dependency bump.

## Fix

Set `DisableLocalhostProtection` on the streamable handler. The guard exists for unauthenticated local servers that a browser page could reach via rebinding. `/mcp` requires a bearer key or OAuth token on every request and browsers never attach those ambiently, so a rebinding page gets the same 401 as any anonymous caller. The SDK's cross-origin protection is left at its default.

## Test

`TestProxiedRequestOnLoopbackIsNotRejected` sends an authenticated `initialize` with `Host: ch-ui.example.com` and a `127.0.0.1` local address in the request context. Without the fix it fails with the exact production error; with it, 200.

No dependency changes. No doc changes needed: the reverse-proxy layout in `docs/mcp.md` and `ch-ui.conf` now works as written.

## Workaround for deployments on 2.10.0

`MCPGODEBUG=disablelocalhostprotection=1` on the CH-UI process, then restart.